### PR TITLE
Call 'wp_mail_failed' action when email fails

### DIFF
--- a/Postman/PostmanWpMail.php
+++ b/Postman/PostmanWpMail.php
@@ -220,7 +220,8 @@ if ( ! class_exists( 'PostmanWpMail' ) ) {
 
 				// write the error to the PHP log
 				$this->logger->error( get_class( $e ) . ' code=' . $e->getCode() . ' message=' . trim( $e->getMessage() ) );
-
+				do_action( 'wp_mail_failed', new WP_Error( $e->getCode(), trim( $e->getMessage() ));
+				
 				// increment the failure counter, unless we are just tesitng
 				if ( ! $testMode && $options->getRunMode() == PostmanOptions::RUN_MODE_PRODUCTION ) {
 					PostmanState::getInstance()->incrementFailedDelivery();


### PR DESCRIPTION
POST SMTP bypasses wordpress's default error handling functionality, meaning that actions designed to be triggered when emails fail to send will not be triggered. This resolves that issue by simply calling the [wp_mail_failed ](https://developer.wordpress.org/reference/hooks/wp_mail_failed/)hook.