### PR TITLE
Fixes fatal error Class 'Mandrill_Error' not found

### DIFF
--- a/Postman/Postman-Mail/mailchimp-mandrill-api-php-da3adc10042e/src/Mandrill.php
+++ b/Postman/Postman-Mail/mailchimp-mandrill-api-php-da3adc10042e/src/Mandrill.php
@@ -149,7 +149,7 @@ class Postman_Mandrill {
     public function castError($result) {
         if($result['status'] !== 'error' || !$result['name']) throw new Postman_Mandrill_Error('We received an unexpected error: ' . json_encode($result));
 
-        $class = (isset(self::$error_map[$result['name']])) ? self::$error_map[$result['name']] : 'Mandrill_Error';
+        $class = (isset(self::$error_map[$result['name']])) ? self::$error_map[$result['name']] : 'Postman_Mandrill_Error';
         return new $class($result['message'], $result['code']);
     }
 


### PR DESCRIPTION
In case an invalid error response comes back, the error object is casted to a `Postman_Mandrill_Error`. However, if no name is set, or the status is not 'error' it falls back to a dynamic error name. The class referenced there (`Mandrill_Error`) does not exist, and should be `Postman_Mandrill_Error`