### PR TITLE
Fixes #1, deprecates and replaces variable text domain usage

### DIFF
--- a/Postman/Postman-Configuration/PostmanConfigurationController.php
+++ b/Postman/Postman-Configuration/PostmanConfigurationController.php
@@ -94,11 +94,11 @@ class PostmanConfigurationController {
 	/**
 	 */
 	private function addLocalizeScriptsToPage() {
-		$warning = __( 'Warning', Postman::TEXT_DOMAIN );
+		$warning = __( 'Warning', 'post-smtp' );
 		/* translators: where %s is the name of the SMTP server */
-		wp_localize_script( 'postman_wizard_script', 'postman_smtp_mitm', sprintf( '%s: %s', $warning, __( 'connected to %1$s instead of %2$s.', Postman::TEXT_DOMAIN ) ) );
+		wp_localize_script( 'postman_wizard_script', 'postman_smtp_mitm', sprintf( '%s: %s', $warning, __( 'connected to %1$s instead of %2$s.', 'post-smtp' ) ) );
 		/* translators: where %d is a port number */
-		wp_localize_script( 'postman_wizard_script', 'postman_wizard_bad_redirect_url', __( 'You are about to configure OAuth 2.0 with an IP address instead of a domain name. This is not permitted. Either assign a real domain name to your site or add a fake one in your local host file.', Postman::TEXT_DOMAIN ) );
+		wp_localize_script( 'postman_wizard_script', 'postman_wizard_bad_redirect_url', __( 'You are about to configure OAuth 2.0 with an IP address instead of a domain name. This is not permitted. Either assign a real domain name to your site or add a fake one in your local host file.', 'post-smtp' ) );
 
 		// user input
 		wp_localize_script( PostmanViewController::POSTMAN_SCRIPT, 'postman_input_sender_email', '#input_' . PostmanOptions::MESSAGE_SENDER_EMAIL );
@@ -131,7 +131,7 @@ class PostmanConfigurationController {
 	 * Register the Configuration screen
 	 */
 	public function addConfigurationSubmenu() {
-		$page = add_submenu_page( null, sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ) ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanConfigurationController::CONFIGURATION_SLUG, array(
+		$page = add_submenu_page( null, sprintf( __( '%s Setup', 'post-smtp' ), __( 'Postman SMTP', 'post-smtp' ) ), __( 'Postman SMTP', 'post-smtp' ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanConfigurationController::CONFIGURATION_SLUG, array(
 				$this,
 				'outputManualConfigurationContent',
 		) );
@@ -155,7 +155,7 @@ class PostmanConfigurationController {
 	 * Register the Setup Wizard screen
 	 */
 	public function addSetupWizardSubmenu() {
-		$page = add_submenu_page( null, sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ) ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG, array(
+		$page = add_submenu_page( null, sprintf( __( '%s Setup', 'post-smtp' ), __( 'Postman SMTP', 'post-smtp' ) ), __( 'Postman SMTP', 'post-smtp' ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG, array(
 				$this,
 				'outputWizardContent',
 		) );
@@ -194,14 +194,14 @@ class PostmanConfigurationController {
 	public function outputManualConfigurationContent() {
 		print '<div class="wrap">';
 
-		PostmanViewController::outputChildPageHeader( __( 'Settings', Postman::TEXT_DOMAIN ), 'advanced_config' );
+		PostmanViewController::outputChildPageHeader( __( 'Settings', 'post-smtp' ), 'advanced_config' );
 		print '<div id="config_tabs"><ul>';
-		print sprintf( '<li><a href="#account_config">%s</a></li>', __( 'Account', Postman::TEXT_DOMAIN ) );
-		print sprintf( '<li><a href="#fallback">%s</a></li>', __( 'Fallback', Postman::TEXT_DOMAIN ) );
-		print sprintf( '<li><a href="#message_config">%s</a></li>', __( 'Message', Postman::TEXT_DOMAIN ) );
-		print sprintf( '<li><a href="#logging_config">%s</a></li>', __( 'Logging', Postman::TEXT_DOMAIN ) );
-		print sprintf( '<li><a href="#advanced_options_config">%s</a></li>', __( 'Advanced', Postman::TEXT_DOMAIN ) );
-		print sprintf( '<li><a href="#notifications">%s</a></li>', __( 'Notifications', Postman::TEXT_DOMAIN ) );
+		print sprintf( '<li><a href="#account_config">%s</a></li>', __( 'Account', 'post-smtp' ) );
+		print sprintf( '<li><a href="#fallback">%s</a></li>', __( 'Fallback', 'post-smtp' ) );
+		print sprintf( '<li><a href="#message_config">%s</a></li>', __( 'Message', 'post-smtp' ) );
+		print sprintf( '<li><a href="#logging_config">%s</a></li>', __( 'Logging', 'post-smtp' ) );
+		print sprintf( '<li><a href="#advanced_options_config">%s</a></li>', __( 'Advanced', 'post-smtp' ) );
+		print sprintf( '<li><a href="#notifications">%s</a></li>', __( 'Notifications', 'post-smtp' ) );
 		print '</ul>';
 
 		print '<form method="post" action="options.php">';
@@ -239,29 +239,29 @@ class PostmanConfigurationController {
 
         <!-- Fallback Start -->
         <section id="fallback">
-            <h2><?php esc_html_e( 'Failed emails fallback', Postman::TEXT_DOMAIN ); ?></h2>
-            <p><?php esc_html_e( 'By enable this option, if your email is fail to send Post SMTP will try to use the SMTP service you define here.', Postman::TEXT_DOMAIN ); ?></p>
+            <h2><?php esc_html_e( 'Failed emails fallback', 'post-smtp' ); ?></h2>
+            <p><?php esc_html_e( 'By enable this option, if your email is fail to send Post SMTP will try to use the SMTP service you define here.', 'post-smtp' ); ?></p>
             <table class="form-table">
                 <tr valign="">
-                    <th scope="row"><?php _e( 'Use Fallback?', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e( 'Use Fallback?', 'post-smtp' ); ?></th>
                     <td>
                         <label>
                             <input name="postman_options[<?php echo PostmanOptions::FALLBACK_SMTP_ENABLED; ?>]" type="radio"
                                    value="no"<?php echo checked( $this->options->getFallbackIsEnabled(), 'no' ); ?>>
-                            <?php _e( 'No', Postman::TEXT_DOMAIN ); ?>
+                            <?php _e( 'No', 'post-smtp' ); ?>
                         </label>
                         &nbsp;
                         <label>
                             <?php $checked = checked( $this->options->getFallbackIsEnabled(), 'yes', false ); ?>
                             <input name="postman_options[<?php echo PostmanOptions::FALLBACK_SMTP_ENABLED; ?>]" type="radio"
                                    value="yes"<?php echo checked( $this->options->getFallbackIsEnabled(), 'yes' ); ?>>
-                            <?php _e( 'Yes', Postman::TEXT_DOMAIN ); ?>
+                            <?php _e( 'Yes', 'post-smtp' ); ?>
                         </label>
                     </td>
                 </tr>
 
                 <tr>
-                    <th scope="row"><?php _e('Outgoing Mail Server', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e('Outgoing Mail Server', 'post-smtp' ); ?></th>
                     <?php $host = $this->options->getFallbackHostname(); ?>
                     <td>
                         <input type="text" id="fallback-smtp-host" name="postman_options[<?php echo PostmanOptions::FALLBACK_SMTP_HOSTNAME; ?>]"
@@ -270,7 +270,7 @@ class PostmanConfigurationController {
                 </tr>
 
                 <tr>
-                    <th scope="row"><?php _e('Mail Server Port', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e('Mail Server Port', 'post-smtp' ); ?></th>
                     <?php $port = $this->options->getFallbackPort(); ?>
                     <td>
                         <input type="number" id="fallback-smtp-port" name="postman_options[<?php echo PostmanOptions::FALLBACK_SMTP_PORT; ?>]"
@@ -279,12 +279,12 @@ class PostmanConfigurationController {
                 </tr>
 
                 <tr>
-                    <th scope="row"><?php _e('Security', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e('Security', 'post-smtp' ); ?></th>
                     <?php
                     $security_options = array(
-                            'none' => __( 'None', Postman::TEXT_DOMAIN ),
-                            'ssl' => __( 'SSL', Postman::TEXT_DOMAIN ),
-                            'tls' => __( 'TLS', Postman::TEXT_DOMAIN ),
+                            'none' => __( 'None', 'post-smtp' ),
+                            'ssl' => __( 'SSL', 'post-smtp' ),
+                            'tls' => __( 'TLS', 'post-smtp' ),
                     );
                     ?>
                     <td>
@@ -302,36 +302,36 @@ class PostmanConfigurationController {
                 </tr>
 
 				<tr>
-					<th scope="row"><?php _e('From Email', Postman::TEXT_DOMAIN ); ?></th>
+					<th scope="row"><?php _e('From Email', 'post-smtp' ); ?></th>
 					<td>
 						<input type="email" id="fallback-smtp-from-email"
 							   value="<?php echo $this->options->getFallbackFromEmail(); ?>"
 							   name="postman_options[<?php echo PostmanOptions::FALLBACK_FROM_EMAIL; ?>]"
 						>
 						<br>
-						<small><?php _e( "Use allowed email, for example: If you are using Gmail, type your Gmail adress.", Postman::TEXT_DOMAIN ); ?></small>
+						<small><?php _e( "Use allowed email, for example: If you are using Gmail, type your Gmail adress.", 'post-smtp' ); ?></small>
 					</td>
 				</tr>
 
                 <tr valign="">
-                    <th scope="row"><?php _e( 'Use SMTP Authentication?', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e( 'Use SMTP Authentication?', 'post-smtp' ); ?></th>
                     <td>
                         <label>
                             <input name="postman_options[<?php echo PostmanOptions::FALLBACK_SMTP_USE_AUTH; ?>]"
                                    type="radio" value="none"<?php checked( $this->options->getFallbackAuth(), 'none' ); ?>>
-                            <?php _e( 'No', Postman::TEXT_DOMAIN ); ?>
+                            <?php _e( 'No', 'post-smtp' ); ?>
                         </label>
                         &nbsp;
                         <label>
                             <input name="postman_options[<?php echo PostmanOptions::FALLBACK_SMTP_USE_AUTH; ?>]"
                                    type="radio" value="login"<?php checked( $this->options->getFallbackAuth(), 'login' ); ?>>
-                            <?php _e( 'Yes', Postman::TEXT_DOMAIN ); ?>
+                            <?php _e( 'Yes', 'post-smtp' ); ?>
                         </label>
                     </td>
                 </tr>
 
                 <tr>
-                    <th scope="row"><?php _e('User name', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e('User name', 'post-smtp' ); ?></th>
                     <td>
                         <input type="text" id="fallback-smtp-username"
                                value="<?php echo $this->options->getFallbackUsername(); ?>"
@@ -341,7 +341,7 @@ class PostmanConfigurationController {
                 </tr>
 
                 <tr>
-                    <th scope="row"><?php _e('Password', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e('Password', 'post-smtp' ); ?></th>
                     <td>
                         <input type="password" id="fallback-smtp-password"
                                value="<?php echo PostmanUtils::obfuscatePassword( $this->options->getFallbackPassword() ); ?>"
@@ -408,7 +408,7 @@ class PostmanConfigurationController {
 		// construct Wizard
 		print '<div class="wrap">';
 
-		PostmanViewController::outputChildPageHeader( __( 'Setup Wizard', Postman::TEXT_DOMAIN ) );
+		PostmanViewController::outputChildPageHeader( __( 'Setup Wizard', 'post-smtp' ) );
 
 		print '<form id="postman_wizard" method="post" action="options.php">';
 
@@ -440,12 +440,12 @@ class PostmanConfigurationController {
 		settings_fields( PostmanAdminController::SETTINGS_GROUP_NAME );
 
 		// Wizard Step 0
-		printf( '<h5>%s</h5>', _x( 'Import Configuration', 'Wizard Step Title', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', _x( 'Import Configuration', 'Wizard Step Title', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', _x( 'Import configuration from another plugin?', 'Wizard Step Title', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'If you had a working configuration with another Plugin, the Setup Wizard can begin with those settings.', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', _x( 'Import configuration from another plugin?', 'Wizard Step Title', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'If you had a working configuration with another Plugin, the Setup Wizard can begin with those settings.', 'post-smtp' ) );
 		print '<table class="input_auth_type">';
-		printf( '<tr><td><input type="radio" id="import_none" name="input_plugin" value="%s" checked="checked"></input></td><td><label> %s</label></td></tr>', 'none', __( 'None', Postman::TEXT_DOMAIN ) );
+		printf( '<tr><td><input type="radio" id="import_none" name="input_plugin" value="%s" checked="checked"></input></td><td><label> %s</label></td></tr>', 'none', __( 'None', 'post-smtp' ) );
 
 		if ( $this->importableConfiguration->isImportAvailable() ) {
 			foreach ( $this->importableConfiguration->getAvailableOptions() as $options ) {
@@ -456,20 +456,20 @@ class PostmanConfigurationController {
 		print '</fieldset>';
 
 		// Wizard Step 1
-		printf( '<h5>%s</h5>', _x( 'Sender Details', 'Wizard Step Title', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', _x( 'Sender Details', 'Wizard Step Title', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', _x( 'Who is the mail coming from?', 'Wizard Step Title', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'Enter the email address and name you\'d like to send mail as.', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'Please note that to prevent abuse, many email services will <em>not</em> let you send from an email address other than the one you authenticate with.', Postman::TEXT_DOMAIN ) );
-		printf( '<label for="postman_options[sender_email]">%s</label>', __( 'Email Address', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', _x( 'Who is the mail coming from?', 'Wizard Step Title', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'Enter the email address and name you\'d like to send mail as.', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'Please note that to prevent abuse, many email services will <em>not</em> let you send from an email address other than the one you authenticate with.', 'post-smtp' ) );
+		printf( '<label for="postman_options[sender_email]">%s</label>', __( 'Email Address', 'post-smtp' ) );
 		print $this->settingsRegistry->from_email_callback();
 		print '<br/>';
-		printf( '<label for="postman_options[sender_name]">%s</label>', __( 'Name', Postman::TEXT_DOMAIN ) );
+		printf( '<label for="postman_options[sender_name]">%s</label>', __( 'Name', 'post-smtp' ) );
 		print $this->settingsRegistry->sender_name_callback();
 		print '</fieldset>';
 
 		// Wizard Step 2
-		printf( '<h5>%s</h5>', __( 'Outgoing Mail Server Hostname', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Outgoing Mail Server Hostname', 'post-smtp' ) );
 		print '<fieldset>';
 		foreach ( PostmanTransportRegistry::getInstance()->getTransports() as $transport ) {
 			$transport->printWizardMailServerHostnameStep();
@@ -477,11 +477,11 @@ class PostmanConfigurationController {
 		print '</fieldset>';
 
 		// Wizard Step 3
-		printf( '<h5>%s</h5>', __( 'Connectivity Test', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Connectivity Test', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', __( 'How will the connection to the mail server be established?', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'Your connection settings depend on what your email service provider offers, and what your WordPress host allows.', Postman::TEXT_DOMAIN ) );
-		printf( '<p id="connectivity_test_status">%s: <span id="port_test_status">%s</span></p>', __( 'Connectivity Test', Postman::TEXT_DOMAIN ), _x( 'Ready', 'TCP Port Test Status', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', __( 'How will the connection to the mail server be established?', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'Your connection settings depend on what your email service provider offers, and what your WordPress host allows.', 'post-smtp' ) );
+		printf( '<p id="connectivity_test_status">%s: <span id="port_test_status">%s</span></p>', __( 'Connectivity Test', 'post-smtp' ), _x( 'Ready', 'TCP Port Test Status', 'post-smtp' ) );
 		printf( '<p class="ajax-loader" style="display:none"><img src="%s"/></p>', plugins_url( 'post-smtp/style/ajax-loader.gif' ) );
 		printf( '<input type="hidden" id="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::TRANSPORT_TYPE );
 		printf( '<input type="hidden" id="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::PORT );
@@ -489,27 +489,27 @@ class PostmanConfigurationController {
 		printf( '<input type="hidden" id="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::AUTHENTICATION_TYPE );
 		print '<p id="wizard_recommendation"></p>';
 		/* Translators: Where %1$s is the socket identifier and %2$s is the authentication type */
-		printf( '<p class="user_override" style="display:none"><label><span>%s:</span></label> <table id="user_socket_override" class="user_override"></table></p>', _x( 'Socket', 'A socket is the network term for host and port together', Postman::TEXT_DOMAIN ) );
-		printf( '<p class="user_override" style="display:none"><label><span>%s:</span></label> <table id="user_auth_override" class="user_override"></table></p>', __( 'Authentication', Postman::TEXT_DOMAIN ) );
+		printf( '<p class="user_override" style="display:none"><label><span>%s:</span></label> <table id="user_socket_override" class="user_override"></table></p>', _x( 'Socket', 'A socket is the network term for host and port together', 'post-smtp' ) );
+		printf( '<p class="user_override" style="display:none"><label><span>%s:</span></label> <table id="user_auth_override" class="user_override"></table></p>', __( 'Authentication', 'post-smtp' ) );
 		print ('<p><span id="smtp_mitm" style="display:none; background-color:yellow"></span></p>') ;
-		$warning = __( 'Warning', Postman::TEXT_DOMAIN );
-		$clearCredentialsWarning = __( 'This configuration option will send your authorization credentials in the clear.', Postman::TEXT_DOMAIN );
+		$warning = __( 'Warning', 'post-smtp' );
+		$clearCredentialsWarning = __( 'This configuration option will send your authorization credentials in the clear.', 'post-smtp' );
 		printf( '<p id="smtp_not_secure" style="display:none"><span style="background-color:yellow">%s: %s</span></p>', $warning, $clearCredentialsWarning );
 		print '</fieldset>';
 
 		// Wizard Step 4
-		printf( '<h5>%s</h5>', __( 'Authentication', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Authentication', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', __( 'How will you prove your identity to the mail server?', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', __( 'How will you prove your identity to the mail server?', 'post-smtp' ) );
 		foreach ( PostmanTransportRegistry::getInstance()->getTransports() as $transport ) {
 			$transport->printWizardAuthenticationStep();
 		}
 		print '</fieldset>';
 
 		// Wizard Step 5 - Notificiations
-		printf( '<h5>%s</h5>', __( 'Notifications', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Notifications', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', __( 'Select a notify service to notify you when an email is failed to delivered.', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', __( 'Select a notify service to notify you when an email is failed to delivered.', 'post-smtp' ) );
 
 		?>
 		<select id="input_notification_service" class="input_notification_service" name="postman_options[notification_service]">
@@ -518,17 +518,17 @@ class PostmanConfigurationController {
 			<option value="slack">Slack</option>
 		</select>
 		<div id="pushover_cred" style="display: none;">
-			<h2><?php _e( 'Pushover Credentials', Postman::TEXT_DOMAIN ); ?></h2>
+			<h2><?php _e( 'Pushover Credentials', 'post-smtp' ); ?></h2>
 			<table class="form-table">
 				<tbody>
 					<tr>
-						<th scope="row"><?php _e( 'Pushover User Key', Postman::TEXT_DOMAIN ); ?></th>
+						<th scope="row"><?php _e( 'Pushover User Key', 'post-smtp' ); ?></th>
 						<td>
 							<input type="password" id="pushover_user" name="postman_options[pushover_user]" value="">
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php _e( 'Pushover App Token', Postman::TEXT_DOMAIN ); ?></th>
+						<th scope="row"><?php _e( 'Pushover App Token', 'post-smtp' ); ?></th>
 						<td>
 							<input type="password" id="pushover_token" name="postman_options[pushover_token]" value="">
 						</td>
@@ -537,15 +537,15 @@ class PostmanConfigurationController {
 			</table>
 		</div>
 		<div id="slack_cred" style="display: none;">
-			<h2><?php _e( 'Slack Credentials', Postman::TEXT_DOMAIN ); ?></h2>
+			<h2><?php _e( 'Slack Credentials', 'post-smtp' ); ?></h2>
 			<table class="form-table">
 				<tbody>
 				<tr>
-					<th scope="row"><?php _e( 'Slack webhook', Postman::TEXT_DOMAIN ); ?></th>
+					<th scope="row"><?php _e( 'Slack webhook', 'post-smtp' ); ?></th>
 					<td>
 						<input type="password" id="slack_token" name="postman_options[slack_token]" value="">
 						<a target="_blank" class="" href="https://slack.postmansmtp.com/">
-							<?php _e( 'Get your webhook URL here.', Postman::TEXT_DOMAIN ); ?>
+							<?php _e( 'Get your webhook URL here.', 'post-smtp' ); ?>
 						</a>
 					</td>
 				</tr>
@@ -554,20 +554,20 @@ class PostmanConfigurationController {
 		</div>
 
         <div id="use-chrome-extension">
-            <h2><?php _e( 'Push To Chrome Extension', Postman::TEXT_DOMAIN ); ?></h2>
+            <h2><?php _e( 'Push To Chrome Extension', 'post-smtp' ); ?></h2>
             <table class="form-table">
                 <tbody>
                 <tr>
-                    <th scope="row"><?php _e( 'This is an extra notification to the selection above', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e( 'This is an extra notification to the selection above', 'post-smtp' ); ?></th>
                     <td>
                         <input type="checkbox" id="notification_use_chrome" name="postman_options[notification_use_chrome]">
                         <a target="_blank" class="" href="https://chrome.google.com/webstore/detail/npklmbkpbknkmbohdbpikeidiaekjoch">
-                            <?php _e( 'You can download the chrome extensiom here.', Postman::TEXT_DOMAIN ); ?>
+                            <?php _e( 'You can download the chrome extensiom here.', 'post-smtp' ); ?>
                         </a>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><?php _e( 'Your UID as you see in the extension.', Postman::TEXT_DOMAIN ); ?></th>
+                    <th scope="row"><?php _e( 'Your UID as you see in the extension.', 'post-smtp' ); ?></th>
                     <td>
                         <input type="password" id="notification_chrome_uid" name="postman_options[notification_chrome_uid]" value="">
                     </td>
@@ -580,14 +580,14 @@ class PostmanConfigurationController {
 		print '</fieldset>';
 
 		// Wizard Step 6
-		printf( '<h5>%s</h5>', _x( 'Finish', 'The final step of the Wizard', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', _x( 'Finish', 'The final step of the Wizard', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', _x( 'You\'re Done!', 'Wizard Step Title', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', _x( 'You\'re Done!', 'Wizard Step Title', 'post-smtp' ) );
 		print '<section>';
-		printf( '<p>%s</p>', __( 'Click Finish to save these settings, then:', Postman::TEXT_DOMAIN ) );
+		printf( '<p>%s</p>', __( 'Click Finish to save these settings, then:', 'post-smtp' ) );
 		print '<ul style="margin-left: 20px">';
-		printf( '<li class="wizard-auth-oauth2">%s</li>', __( 'Grant permission with the Email Provider for Postman to send email and', Postman::TEXT_DOMAIN ) );
-		printf( '<li>%s</li>', __( 'Send yourself a Test Email to make sure everything is working!', Postman::TEXT_DOMAIN ) );
+		printf( '<li class="wizard-auth-oauth2">%s</li>', __( 'Grant permission with the Email Provider for Postman to send email and', 'post-smtp' ) );
+		printf( '<li>%s</li>', __( 'Send yourself a Test Email to make sure everything is working!', 'post-smtp' ) );
 		print '</ul>';
 		print '</section>';
 		print '</fieldset>';
@@ -730,7 +730,7 @@ class PostmanManageConfigurationAjaxHandler extends PostmanAbstractAjaxHandler {
 			wp_send_json_success( $response );
 		} else {
 			/* translators: where %s is the URL to the Connectivity Test page */
-			$configuration ['message'] = sprintf( __( 'Postman can\'t find any way to send mail on your system. Run a <a href="%s">connectivity test</a>.', Postman::TEXT_DOMAIN ), PostmanViewController::getPageUrl( PostmanViewController::PORT_TEST_SLUG ) );
+			$configuration ['message'] = sprintf( __( 'Postman can\'t find any way to send mail on your system. Run a <a href="%s">connectivity test</a>.', 'post-smtp' ), PostmanViewController::getPageUrl( PostmanViewController::PORT_TEST_SLUG ) );
 			$response ['configuration'] = $configuration;
 			if ( $this->logger->isTrace() ) {
 				$this->logger->trace( 'configuration:' );

--- a/Postman/Postman-Configuration/PostmanRegisterConfigurationSettings.php
+++ b/Postman/Postman-Configuration/PostmanRegisterConfigurationSettings.php
@@ -28,23 +28,23 @@ class PostmanSettingsRegistry {
 			) );
 
 			// Sanitize
-			add_settings_section( 'transport_section', __( 'Transport', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( 'transport_section', __( 'Transport', 'post-smtp' ), array(
 					$this,
 					'printTransportSectionInfo',
 			), 'transport_options' );
 
-			add_settings_field( PostmanOptions::TRANSPORT_TYPE, _x( 'Type', '(i.e.) What kind is it?', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::TRANSPORT_TYPE, _x( 'Type', '(i.e.) What kind is it?', 'post-smtp' ), array(
 					$this,
 					'transport_type_callback',
 			), 'transport_options', 'transport_section' );
 
 			// the Message From section
-			add_settings_section( PostmanAdminController::MESSAGE_FROM_SECTION, _x( 'From Address', 'The Message Sender Email Address', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::MESSAGE_FROM_SECTION, _x( 'From Address', 'The Message Sender Email Address', 'post-smtp' ), array(
 					$this,
 					'printMessageFromSectionInfo',
 			), PostmanAdminController::MESSAGE_FROM_OPTIONS );
 
-			add_settings_field( PostmanOptions::MESSAGE_SENDER_EMAIL, __( 'Email Address', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::MESSAGE_SENDER_EMAIL, __( 'Email Address', 'post-smtp' ), array(
 					$this,
 					'from_email_callback',
 			), PostmanAdminController::MESSAGE_FROM_OPTIONS, PostmanAdminController::MESSAGE_FROM_SECTION );
@@ -54,7 +54,7 @@ class PostmanSettingsRegistry {
 					'prevent_from_email_override_callback',
 			), PostmanAdminController::MESSAGE_FROM_OPTIONS, PostmanAdminController::MESSAGE_FROM_SECTION );
 
-			add_settings_field( PostmanOptions::MESSAGE_SENDER_NAME, __( 'Name', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::MESSAGE_SENDER_NAME, __( 'Name', 'post-smtp' ), array(
 					$this,
 					'sender_name_callback',
 			), PostmanAdminController::MESSAGE_FROM_OPTIONS, PostmanAdminController::MESSAGE_FROM_SECTION );
@@ -65,38 +65,38 @@ class PostmanSettingsRegistry {
 			), PostmanAdminController::MESSAGE_FROM_OPTIONS, PostmanAdminController::MESSAGE_FROM_SECTION );
 
 			// the Additional Addresses section
-			add_settings_section( PostmanAdminController::MESSAGE_SECTION, __( 'Additional Email Addresses', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::MESSAGE_SECTION, __( 'Additional Email Addresses', 'post-smtp' ), array(
 					$this,
 					'printMessageSectionInfo',
 			), PostmanAdminController::MESSAGE_OPTIONS );
 
-			add_settings_field( PostmanOptions::REPLY_TO, __( 'Reply-To', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::REPLY_TO, __( 'Reply-To', 'post-smtp' ), array(
 					$this,
 					'reply_to_callback',
 			), PostmanAdminController::MESSAGE_OPTIONS, PostmanAdminController::MESSAGE_SECTION );
 
-			add_settings_field( PostmanOptions::FORCED_TO_RECIPIENTS, __( 'To Recipient(s)', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::FORCED_TO_RECIPIENTS, __( 'To Recipient(s)', 'post-smtp' ), array(
 					$this,
 					'to_callback',
 			), PostmanAdminController::MESSAGE_OPTIONS, PostmanAdminController::MESSAGE_SECTION );
 
-			add_settings_field( PostmanOptions::FORCED_CC_RECIPIENTS, __( 'Carbon Copy Recipient(s)', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::FORCED_CC_RECIPIENTS, __( 'Carbon Copy Recipient(s)', 'post-smtp' ), array(
 					$this,
 					'cc_callback',
 			), PostmanAdminController::MESSAGE_OPTIONS, PostmanAdminController::MESSAGE_SECTION );
 
-			add_settings_field( PostmanOptions::FORCED_BCC_RECIPIENTS, __( 'Blind Carbon Copy Recipient(s)', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::FORCED_BCC_RECIPIENTS, __( 'Blind Carbon Copy Recipient(s)', 'post-smtp' ), array(
 					$this,
 					'bcc_callback',
 			), PostmanAdminController::MESSAGE_OPTIONS, PostmanAdminController::MESSAGE_SECTION );
 
 			// the Additional Headers section
-			add_settings_section( PostmanAdminController::MESSAGE_HEADERS_SECTION, __( 'Additional Headers', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::MESSAGE_HEADERS_SECTION, __( 'Additional Headers', 'post-smtp' ), array(
 					$this,
 					'printAdditionalHeadersSectionInfo',
 			), PostmanAdminController::MESSAGE_HEADERS_OPTIONS );
 
-			add_settings_field( PostmanOptions::ADDITIONAL_HEADERS, __( 'Custom Headers', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::ADDITIONAL_HEADERS, __( 'Custom Headers', 'post-smtp' ), array(
 					$this,
 					'headers_callback',
 			), PostmanAdminController::MESSAGE_HEADERS_OPTIONS, PostmanAdminController::MESSAGE_HEADERS_SECTION );
@@ -104,123 +104,123 @@ class PostmanSettingsRegistry {
 			// Fallback
 
 			// the Email Validation section
-			add_settings_section( PostmanAdminController::EMAIL_VALIDATION_SECTION, __( 'Validation', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::EMAIL_VALIDATION_SECTION, __( 'Validation', 'post-smtp' ), array(
 					$this,
 					'printEmailValidationSectionInfo',
 			), PostmanAdminController::EMAIL_VALIDATION_OPTIONS );
 
-			add_settings_field( PostmanOptions::ENVELOPE_SENDER, __( 'Email Address', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::ENVELOPE_SENDER, __( 'Email Address', 'post-smtp' ), array(
 					$this,
 					'disable_email_validation_callback',
 			), PostmanAdminController::EMAIL_VALIDATION_OPTIONS, PostmanAdminController::EMAIL_VALIDATION_SECTION );
 
 			// the Logging section
-			add_settings_section( PostmanAdminController::LOGGING_SECTION, __( 'Email Log Settings', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::LOGGING_SECTION, __( 'Email Log Settings', 'post-smtp' ), array(
 					$this,
 					'printLoggingSectionInfo',
 			), PostmanAdminController::LOGGING_OPTIONS );
 
-			add_settings_field( 'logging_status', __( 'Enable Logging', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( 'logging_status', __( 'Enable Logging', 'post-smtp' ), array(
 					$this,
 					'loggingStatusInputField',
 			), PostmanAdminController::LOGGING_OPTIONS, PostmanAdminController::LOGGING_SECTION );
 
-			add_settings_field( 'logging_max_entries', __( 'Maximum Log Entries', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( 'logging_max_entries', __( 'Maximum Log Entries', 'post-smtp' ), array(
 					$this,
 					'loggingMaxEntriesInputField',
 			), PostmanAdminController::LOGGING_OPTIONS, PostmanAdminController::LOGGING_SECTION );
 
-			add_settings_field( PostmanOptions::TRANSCRIPT_SIZE, __( 'Maximum Transcript Size', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::TRANSCRIPT_SIZE, __( 'Maximum Transcript Size', 'post-smtp' ), array(
 					$this,
 					'transcriptSizeInputField',
 			), PostmanAdminController::LOGGING_OPTIONS, PostmanAdminController::LOGGING_SECTION );
 
 			// the Network section
-			add_settings_section( PostmanAdminController::NETWORK_SECTION, __( 'Network Settings', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::NETWORK_SECTION, __( 'Network Settings', 'post-smtp' ), array(
 					$this,
 					'printNetworkSectionInfo',
 			), PostmanAdminController::NETWORK_OPTIONS );
 
-			add_settings_field( 'connection_timeout', _x( 'TCP Connection Timeout (sec)', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( 'connection_timeout', _x( 'TCP Connection Timeout (sec)', 'Configuration Input Field', 'post-smtp' ), array(
 					$this,
 					'connection_timeout_callback',
 			), PostmanAdminController::NETWORK_OPTIONS, PostmanAdminController::NETWORK_SECTION );
 
-			add_settings_field( 'read_timeout', _x( 'TCP Read Timeout (sec)', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( 'read_timeout', _x( 'TCP Read Timeout (sec)', 'Configuration Input Field', 'post-smtp' ), array(
 					$this,
 					'read_timeout_callback',
 			), PostmanAdminController::NETWORK_OPTIONS, PostmanAdminController::NETWORK_SECTION );
 
 			// the Advanced section
-			add_settings_section( PostmanAdminController::ADVANCED_SECTION, _x( 'Miscellaneous Settings', 'Configuration Section Title', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::ADVANCED_SECTION, _x( 'Miscellaneous Settings', 'Configuration Section Title', 'post-smtp' ), array(
 					$this,
 					'printAdvancedSectionInfo',
 			), PostmanAdminController::ADVANCED_OPTIONS );
 
-			add_settings_field( PostmanOptions::LOG_LEVEL, _x( 'PHP Log Level', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::LOG_LEVEL, _x( 'PHP Log Level', 'Configuration Input Field', 'post-smtp' ), array(
 					$this,
 					'log_level_callback',
 			), PostmanAdminController::ADVANCED_OPTIONS, PostmanAdminController::ADVANCED_SECTION );
 
-			add_settings_field( PostmanOptions::RUN_MODE, _x( 'Delivery Mode', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::RUN_MODE, _x( 'Delivery Mode', 'Configuration Input Field', 'post-smtp' ), array(
 					$this,
 					'runModeCallback',
 			), PostmanAdminController::ADVANCED_OPTIONS, PostmanAdminController::ADVANCED_SECTION );
 
-			add_settings_field( PostmanOptions::STEALTH_MODE, _x( 'Stealth Mode', 'This mode removes the Postman X-Mailer signature from emails', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::STEALTH_MODE, _x( 'Stealth Mode', 'This mode removes the Postman X-Mailer signature from emails', 'post-smtp' ), array(
 					$this,
 					'stealthModeCallback',
 			), PostmanAdminController::ADVANCED_OPTIONS, PostmanAdminController::ADVANCED_SECTION );
 
-			add_settings_field( PostmanOptions::TEMPORARY_DIRECTORY, __( 'Temporary Directory', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::TEMPORARY_DIRECTORY, __( 'Temporary Directory', 'post-smtp' ), array(
 					$this,
 					'temporaryDirectoryCallback',
 			), PostmanAdminController::ADVANCED_OPTIONS, PostmanAdminController::ADVANCED_SECTION );
 
 			// Notifications
-			add_settings_section( PostmanAdminController::NOTIFICATIONS_SECTION, _x( 'Notifications Settings', 'Configuration Section Title', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( PostmanAdminController::NOTIFICATIONS_SECTION, _x( 'Notifications Settings', 'Configuration Section Title', 'post-smtp' ), array(
 				$this,
 				'printNotificationsSectionInfo',
 			), PostmanAdminController::NOTIFICATIONS_OPTIONS );
 
-			add_settings_field( PostmanOptions::NOTIFICATION_SERVICE, _x( 'Notification Service', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::NOTIFICATION_SERVICE, _x( 'Notification Service', 'Configuration Input Field', 'post-smtp' ), array(
 				$this,
 				'notification_service_callback',
 			), PostmanAdminController::NOTIFICATIONS_OPTIONS, PostmanAdminController::NOTIFICATIONS_SECTION );
 
 			// Pushover
-			add_settings_section( 'pushover_credentials', _x( 'Pushover Credentials', 'Configuration Section Title', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( 'pushover_credentials', _x( 'Pushover Credentials', 'Configuration Section Title', 'post-smtp' ), array(
 				$this,
 				'printNotificationsSectionInfo',
 			), PostmanAdminController::NOTIFICATIONS_PUSHOVER_CRED );
 
-			add_settings_field( PostmanOptions::PUSHOVER_USER, _x( 'Pushover User Key', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::PUSHOVER_USER, _x( 'Pushover User Key', 'Configuration Input Field', 'post-smtp' ), array(
 				$this,
 				'pushover_user_callback',
 			), PostmanAdminController::NOTIFICATIONS_PUSHOVER_CRED, 'pushover_credentials' );
 
-			add_settings_field( PostmanOptions::PUSHOVER_TOKEN, _x( 'Pushover App Token', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::PUSHOVER_TOKEN, _x( 'Pushover App Token', 'Configuration Input Field', 'post-smtp' ), array(
 				$this,
 				'pushover_token_callback',
 			), PostmanAdminController::NOTIFICATIONS_PUSHOVER_CRED, 'pushover_credentials' );
 
 			// Slack
-			add_settings_section( 'slack_credentials', _x( 'Slack Credentials', 'Configuration Section Title', Postman::TEXT_DOMAIN ), array(
+			add_settings_section( 'slack_credentials', _x( 'Slack Credentials', 'Configuration Section Title', 'post-smtp' ), array(
 				$this,
 				'printNotificationsSectionInfo',
 			), PostmanAdminController::NOTIFICATIONS_SLACK_CRED );
 
-			add_settings_field( PostmanOptions::SLACK_TOKEN, _x( 'Slack Webhook', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+			add_settings_field( PostmanOptions::SLACK_TOKEN, _x( 'Slack Webhook', 'Configuration Input Field', 'post-smtp' ), array(
 				$this,
 				'slack_token_callback',
 			), PostmanAdminController::NOTIFICATIONS_SLACK_CRED, 'slack_credentials' );
 
-            add_settings_field( PostmanOptions::NOTIFICATION_USE_CHROME, _x( 'Push to chrome extension', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+            add_settings_field( PostmanOptions::NOTIFICATION_USE_CHROME, _x( 'Push to chrome extension', 'Configuration Input Field', 'post-smtp' ), array(
                 $this,
                 'notification_use_chrome_callback',
             ), PostmanAdminController::NOTIFICATIONS_OPTIONS, PostmanAdminController::NOTIFICATIONS_SECTION );
 
-            add_settings_field( PostmanOptions::NOTIFICATION_CHROME_UID, _x( 'Chrome Extension UID', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+            add_settings_field( PostmanOptions::NOTIFICATION_CHROME_UID, _x( 'Chrome Extension UID', 'Configuration Input Field', 'post-smtp' ), array(
                 $this,
                 'notification_chrome_uid_callback',
             ), PostmanAdminController::NOTIFICATIONS_OPTIONS, PostmanAdminController::NOTIFICATIONS_SECTION );
@@ -232,31 +232,31 @@ class PostmanSettingsRegistry {
 	 * Print the Transport section info
 	 */
 	public function printTransportSectionInfo() {
-		print __( 'Choose SMTP or a vendor-specific API:', Postman::TEXT_DOMAIN );
+		print __( 'Choose SMTP or a vendor-specific API:', 'post-smtp' );
 	}
 	public function printLoggingSectionInfo() {
-		print __( 'Configure the delivery audit log:', Postman::TEXT_DOMAIN );
+		print __( 'Configure the delivery audit log:', 'post-smtp' );
 	}
 
 	/**
 	 * Print the Section text
 	 */
 	public function printMessageFromSectionInfo() {
-		print sprintf( __( 'This address, like the <b>letterhead</b> printed on a letter, identifies the sender to the recipient. Change this when you are sending on behalf of someone else, for example to use Google\'s <a href="%s">Send Mail As</a> feature. Other plugins, especially Contact Forms, may override this field to be your visitor\'s address.', Postman::TEXT_DOMAIN ), 'https://support.google.com/mail/answer/22370?hl=en' );
+		print sprintf( __( 'This address, like the <b>letterhead</b> printed on a letter, identifies the sender to the recipient. Change this when you are sending on behalf of someone else, for example to use Google\'s <a href="%s">Send Mail As</a> feature. Other plugins, especially Contact Forms, may override this field to be your visitor\'s address.', 'post-smtp' ), 'https://support.google.com/mail/answer/22370?hl=en' );
 	}
 
 	/**
 	 * Print the Section text
 	 */
 	public function printMessageSectionInfo() {
-		print __( 'Separate multiple <b>to</b>/<b>cc</b>/<b>bcc</b> recipients with commas.', Postman::TEXT_DOMAIN );
+		print __( 'Separate multiple <b>to</b>/<b>cc</b>/<b>bcc</b> recipients with commas.', 'post-smtp' );
 	}
 
 	/**
 	 * Print the Section text
 	 */
 	public function printNetworkSectionInfo() {
-		print __( 'Increase the timeouts if your host is intermittenly failing to send mail. Be careful, this also correlates to how long your user must wait if the mail server is unreachable.', Postman::TEXT_DOMAIN );
+		print __( 'Increase the timeouts if your host is intermittenly failing to send mail. Be careful, this also correlates to how long your user must wait if the mail server is unreachable.', 'post-smtp' );
 	}
 
 	/**
@@ -275,14 +275,14 @@ class PostmanSettingsRegistry {
 	 * Print the Section text
 	 */
 	public function printAdditionalHeadersSectionInfo() {
-		print __( 'Specify custom headers (e.g. <code>X-MC-Tags: wordpress-site-A</code>), one per line. Use custom headers with caution as they can negatively affect your Spam score.', Postman::TEXT_DOMAIN );
+		print __( 'Specify custom headers (e.g. <code>X-MC-Tags: wordpress-site-A</code>), one per line. Use custom headers with caution as they can negatively affect your Spam score.', 'post-smtp' );
 	}
 
 	/**
 	 * Print the Email Validation Description
 	 */
 	public function printEmailValidationSectionInfo() {
-		print __( 'E-mail addresses can be validated before sending e-mail, however this may fail with some newer domains.', Postman::TEXT_DOMAIN );
+		print __( 'E-mail addresses can be validated before sending e-mail, however this may fail with some newer domains.', 'post-smtp' );
 	}
 
 	/**
@@ -308,21 +308,21 @@ class PostmanSettingsRegistry {
 	 */
 	public function prevent_from_name_override_callback() {
 		$enforced = $this->options->isPluginSenderNameEnforced();
-		printf( '<input type="checkbox" id="input_prevent_sender_name_override" name="postman_options[prevent_sender_name_override]" %s /> %s', $enforced ? 'checked="checked"' : '', __( 'Prevent <b>plugins</b> and <b>themes</b> from changing this', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="checkbox" id="input_prevent_sender_name_override" name="postman_options[prevent_sender_name_override]" %s /> %s', $enforced ? 'checked="checked"' : '', __( 'Prevent <b>plugins</b> and <b>themes</b> from changing this', 'post-smtp' ) );
 	}
 
 	/**
 	 * Get the settings option array and print one of its values
 	 */
 	public function from_email_callback() {
-		printf( '<input type="email" id="input_sender_email" name="postman_options[sender_email]" value="%s" size="40" class="required" placeholder="%s"/>', null !== $this->options->getMessageSenderEmail() ? esc_attr( $this->options->getMessageSenderEmail() ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="email" id="input_sender_email" name="postman_options[sender_email]" value="%s" size="40" class="required" placeholder="%s"/>', null !== $this->options->getMessageSenderEmail() ? esc_attr( $this->options->getMessageSenderEmail() ) : '', __( 'Required', 'post-smtp' ) );
 	}
 
 	/**
 	 * Print the Section text
 	 */
 	public function printMessageSenderSectionInfo() {
-		print sprintf( __( 'This address, like the <b>return address</b> printed on an envelope, identifies the account owner to the SMTP server.', Postman::TEXT_DOMAIN ), 'https://support.google.com/mail/answer/22370?hl=en' );
+		print sprintf( __( 'This address, like the <b>return address</b> printed on an envelope, identifies the account owner to the SMTP server.', 'post-smtp' ), 'https://support.google.com/mail/answer/22370?hl=en' );
 	}
 
 	/**
@@ -330,7 +330,7 @@ class PostmanSettingsRegistry {
 	 */
 	public function prevent_from_email_override_callback() {
 		$enforced = $this->options->isPluginSenderEmailEnforced();
-		printf( '<input type="checkbox" id="input_prevent_sender_email_override" name="postman_options[prevent_sender_email_override]" %s /> %s', $enforced ? 'checked="checked"' : '', __( 'Prevent <b>plugins</b> and <b>themes</b> from changing this', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="checkbox" id="input_prevent_sender_email_override" name="postman_options[prevent_sender_email_override]" %s /> %s', $enforced ? 'checked="checked"' : '', __( 'Prevent <b>plugins</b> and <b>themes</b> from changing this', 'post-smtp' ) );
 	}
 
 	/**
@@ -343,8 +343,8 @@ class PostmanSettingsRegistry {
 			$disabled = 'disabled="disabled" ';
 		}
 		printf( '<select ' . $disabled . 'id="input_%2$s" class="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::MAIL_LOG_ENABLED_OPTION );
-		printf( '<option value="%s" %s>%s</option>', PostmanOptions::MAIL_LOG_ENABLED_OPTION_YES, $this->options->isMailLoggingEnabled() ? 'selected="selected"' : '', __( 'Yes', Postman::TEXT_DOMAIN ) );
-		printf( '<option value="%s" %s>%s</option>', PostmanOptions::MAIL_LOG_ENABLED_OPTION_NO, ! $this->options->isMailLoggingEnabled() ? 'selected="selected"' : '', __( 'No', Postman::TEXT_DOMAIN ) );
+		printf( '<option value="%s" %s>%s</option>', PostmanOptions::MAIL_LOG_ENABLED_OPTION_YES, $this->options->isMailLoggingEnabled() ? 'selected="selected"' : '', __( 'Yes', 'post-smtp' ) );
+		printf( '<option value="%s" %s>%s</option>', PostmanOptions::MAIL_LOG_ENABLED_OPTION_NO, ! $this->options->isMailLoggingEnabled() ? 'selected="selected"' : '', __( 'No', 'post-smtp' ) );
 		printf( '</select>' );
 	}
 	public function loggingMaxEntriesInputField() {
@@ -354,7 +354,7 @@ class PostmanSettingsRegistry {
 		$inputOptionsSlug = PostmanOptions::POSTMAN_OPTIONS;
 		$inputTranscriptSlug = PostmanOptions::TRANSCRIPT_SIZE;
 		$inputValue = $this->options->getTranscriptSize();
-		$inputDescription = __( 'Change this value if you can\'t see the beginning of the transcript because your messages are too big.', Postman::TEXT_DOMAIN );
+		$inputDescription = __( 'Change this value if you can\'t see the beginning of the transcript because your messages are too big.', 'post-smtp' );
 		printf( '<input type="text" id="input%2$s" name="%1$s[%2$s]" value="%3$s"/><br/><span class="postman_input_description">%4$s</span>', $inputOptionsSlug, $inputTranscriptSlug, $inputValue, $inputDescription );
 	}
 
@@ -397,22 +397,22 @@ class PostmanSettingsRegistry {
 	 */
 	public function disable_email_validation_callback() {
 		$disabled = $this->options->isEmailValidationDisabled();
-		printf( '<input type="checkbox" id="%2$s" name="%1$s[%2$s]" %3$s /> %4$s', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::DISABLE_EMAIL_VALIDAITON, $disabled ? 'checked="checked"' : '', __( 'Disable e-mail validation', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="checkbox" id="%2$s" name="%1$s[%2$s]" %3$s /> %4$s', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::DISABLE_EMAIL_VALIDAITON, $disabled ? 'checked="checked"' : '', __( 'Disable e-mail validation', 'post-smtp' ) );
 	}
 
 	/**
 	 * Get the settings option array and print one of its values
 	 */
 	public function log_level_callback() {
-		$inputDescription = sprintf( __( 'Log Level specifies the level of detail written to the <a target="_blank" href="%s">WordPress Debug log</a> - view the log with <a target-"_new" href="%s">Debug</a>.', Postman::TEXT_DOMAIN ), 'https://codex.wordpress.org/Debugging_in_WordPress', 'https://wordpress.org/plugins/debug/' );
+		$inputDescription = sprintf( __( 'Log Level specifies the level of detail written to the <a target="_blank" href="%s">WordPress Debug log</a> - view the log with <a target-"_new" href="%s">Debug</a>.', 'post-smtp' ), 'https://codex.wordpress.org/Debugging_in_WordPress', 'https://wordpress.org/plugins/debug/' );
 		printf( '<select id="input_%2$s" class="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::LOG_LEVEL );
 		$currentKey = $this->options->getLogLevel();
-		$this->printSelectOption( __( 'Off', Postman::TEXT_DOMAIN ), PostmanLogger::OFF_INT, $currentKey );
-		$this->printSelectOption( __( 'Trace', Postman::TEXT_DOMAIN ), PostmanLogger::TRACE_INT, $currentKey );
-		$this->printSelectOption( __( 'Debug', Postman::TEXT_DOMAIN ), PostmanLogger::DEBUG_INT, $currentKey );
-		$this->printSelectOption( __( 'Info', Postman::TEXT_DOMAIN ), PostmanLogger::INFO_INT, $currentKey );
-		$this->printSelectOption( __( 'Warning', Postman::TEXT_DOMAIN ), PostmanLogger::WARN_INT, $currentKey );
-		$this->printSelectOption( __( 'Error', Postman::TEXT_DOMAIN ), PostmanLogger::ERROR_INT, $currentKey );
+		$this->printSelectOption( __( 'Off', 'post-smtp' ), PostmanLogger::OFF_INT, $currentKey );
+		$this->printSelectOption( __( 'Trace', 'post-smtp' ), PostmanLogger::TRACE_INT, $currentKey );
+		$this->printSelectOption( __( 'Debug', 'post-smtp' ), PostmanLogger::DEBUG_INT, $currentKey );
+		$this->printSelectOption( __( 'Info', 'post-smtp' ), PostmanLogger::INFO_INT, $currentKey );
+		$this->printSelectOption( __( 'Warning', 'post-smtp' ), PostmanLogger::WARN_INT, $currentKey );
+		$this->printSelectOption( __( 'Error', 'post-smtp' ), PostmanLogger::ERROR_INT, $currentKey );
 		printf( '</select><br/><span class="postman_input_description">%s</span>', $inputDescription );
 	}
 
@@ -421,9 +421,9 @@ class PostmanSettingsRegistry {
 		printf( '<select id="input_%2$s" class="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::NOTIFICATION_SERVICE );
 		$currentKey = $this->options->getNotificationService();
 
-		$this->printSelectOption( __( 'Email', Postman::TEXT_DOMAIN ), 'default', $currentKey );
-		$this->printSelectOption( __( 'Pushover', Postman::TEXT_DOMAIN ), 'pushover', $currentKey );
-		$this->printSelectOption( __( 'Slack', Postman::TEXT_DOMAIN ), 'slack', $currentKey );
+		$this->printSelectOption( __( 'Email', 'post-smtp' ), 'default', $currentKey );
+		$this->printSelectOption( __( 'Pushover', 'post-smtp' ), 'pushover', $currentKey );
+		$this->printSelectOption( __( 'Slack', 'post-smtp' ), 'slack', $currentKey );
 		printf( '</select><br/><span class="postman_input_description">%s</span>', $inputDescription );
 	}
 
@@ -446,7 +446,7 @@ class PostmanSettingsRegistry {
 
 	public function slack_token_callback() {
 		printf( '<input type="password" id="slack_token" name="%s[%s]" value="%s" />', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::SLACK_TOKEN, $this->options->getSlackToken() );
-		echo '<a target="_blank" href="https://slack.postmansmtp.com/">' . __( 'Get your webhook URL here', Postman::TEXT_DOMAIN ) . '</a>';
+		echo '<a target="_blank" href="https://slack.postmansmtp.com/">' . __( 'Get your webhook URL here', 'post-smtp' ) . '</a>';
 
 	}
 
@@ -455,26 +455,26 @@ class PostmanSettingsRegistry {
 		printf( $optionPattern, $optionKey, $optionKey == $currentKey ? 'selected="selected"' : '', $label );
 	}
 	public function runModeCallback() {
-		$inputDescription = __( 'Delivery mode offers options useful for developing or testing.', Postman::TEXT_DOMAIN );
+		$inputDescription = __( 'Delivery mode offers options useful for developing or testing.', 'post-smtp' );
 		printf( '<select id="input_%2$s" class="input_%2$s" name="%1$s[%2$s]">', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::RUN_MODE );
 		$currentKey = $this->options->getRunMode();
-		$this->printSelectOption( _x( 'Log Email and Send', 'When the server is online to the public, this is "Production" mode', Postman::TEXT_DOMAIN ), PostmanOptions::RUN_MODE_PRODUCTION, $currentKey );
-		$this->printSelectOption( __( 'Log Email and Delete', Postman::TEXT_DOMAIN ), PostmanOptions::RUN_MODE_LOG_ONLY, $currentKey );
-		$this->printSelectOption( __( 'Delete All Emails', Postman::TEXT_DOMAIN ), PostmanOptions::RUN_MODE_IGNORE, $currentKey );
+		$this->printSelectOption( _x( 'Log Email and Send', 'When the server is online to the public, this is "Production" mode', 'post-smtp' ), PostmanOptions::RUN_MODE_PRODUCTION, $currentKey );
+		$this->printSelectOption( __( 'Log Email and Delete', 'post-smtp' ), PostmanOptions::RUN_MODE_LOG_ONLY, $currentKey );
+		$this->printSelectOption( __( 'Delete All Emails', 'post-smtp' ), PostmanOptions::RUN_MODE_IGNORE, $currentKey );
 		printf( '</select><br/><span class="postman_input_description">%s</span>', $inputDescription );
 	}
 
 	public function stealthModeCallback() {
-		printf( '<input type="checkbox" id="input_%2$s" class="input_%2$s" name="%1$s[%2$s]" %3$s /> %4$s', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::STEALTH_MODE, $this->options->isStealthModeEnabled() ? 'checked="checked"' : '', __( 'Remove the Postman X-Header signature from messages', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="checkbox" id="input_%2$s" class="input_%2$s" name="%1$s[%2$s]" %3$s /> %4$s', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::STEALTH_MODE, $this->options->isStealthModeEnabled() ? 'checked="checked"' : '', __( 'Remove the Postman X-Header signature from messages', 'post-smtp' ) );
 	}
 
 	public function temporaryDirectoryCallback() {
 		$inputDescription = __( 'Lockfiles are written here to prevent users from triggering an OAuth 2.0 token refresh at the same time.' );
 		printf( '<input type="text" id="input_%2$s" name="%1$s[%2$s]" value="%3$s" />', PostmanOptions::POSTMAN_OPTIONS, PostmanOptions::TEMPORARY_DIRECTORY, $this->options->getTempDirectory() );
 		if ( PostmanState::getInstance()->isFileLockingEnabled() ) {
-			printf( ' <span style="color:green">%s</span></br><span class="postman_input_description">%s</span>', __( 'Valid', Postman::TEXT_DOMAIN ), $inputDescription );
+			printf( ' <span style="color:green">%s</span></br><span class="postman_input_description">%s</span>', __( 'Valid', 'post-smtp' ), $inputDescription );
 		} else {
-			printf( ' <span style="color:red">%s</span></br><span class="postman_input_description">%s</span>', __( 'Invalid', Postman::TEXT_DOMAIN ), $inputDescription );
+			printf( ' <span style="color:red">%s</span></br><span class="postman_input_description">%s</span>', __( 'Invalid', 'post-smtp' ), $inputDescription );
 		}
 	}
 
@@ -496,6 +496,6 @@ class PostmanSettingsRegistry {
 	 * Get the settings option array and print one of its values
 	 */
 	public function port_callback( $args ) {
-		printf( '<input type="text" id="input_port" name="postman_options[port]" value="%s" %s placeholder="%s"/>', null !== $this->options->getPort() ? esc_attr( $this->options->getPort() ) : '', isset( $args ['style'] ) ? $args ['style'] : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="text" id="input_port" name="postman_options[port]" value="%s" %s placeholder="%s"/>', null !== $this->options->getPort() ? esc_attr( $this->options->getPort() ) : '', isset( $args ['style'] ) ? $args ['style'] : '', __( 'Required', 'post-smtp' ) );
 	}
 }

--- a/Postman/Postman-Connectivity-Test/PostmanConnectivityTestController.php
+++ b/Postman/Postman-Connectivity-Test/PostmanConnectivityTestController.php
@@ -77,7 +77,7 @@ class PostmanConnectivityTestController {
 	 * Register the Email Test screen
 	 */
 	public function addPortTestSubmenu() {
-		$page = add_submenu_page( null, sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ) ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanConnectivityTestController::PORT_TEST_SLUG, array(
+		$page = add_submenu_page( null, sprintf( __( '%s Setup', 'post-smtp' ), __( 'Postman SMTP', 'post-smtp' ) ), __( 'Postman SMTP', 'post-smtp' ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanConnectivityTestController::PORT_TEST_SLUG, array(
 				$this,
 				'outputPortTestContent',
 		) );
@@ -93,26 +93,26 @@ class PostmanConnectivityTestController {
 	function enqueuePortTestResources() {
 		wp_enqueue_style( PostmanViewController::POSTMAN_STYLE );
 		wp_enqueue_script( 'postman_port_test_script' );
-		$warning = __( 'Warning', Postman::TEXT_DOMAIN );
+		$warning = __( 'Warning', 'post-smtp' );
 		wp_localize_script( PostmanViewController::POSTMAN_SCRIPT, 'postman_hostname_element_name', '#input_' . PostmanOptions::HOSTNAME );
 		PostmanConnectivityTestController::addLocalizeScriptForPortTest();
 	}
 	static function addLocalizeScriptForPortTest() {
 		wp_localize_script( PostmanViewController::POSTMAN_SCRIPT, 'postman_port_test', array(
-				'in_progress' => _x( 'Checking..', 'The "please wait" message', Postman::TEXT_DOMAIN ),
-				'open' => _x( 'Open', 'The port is open', Postman::TEXT_DOMAIN ),
-				'closed' => _x( 'Closed', 'The port is closed', Postman::TEXT_DOMAIN ),
-				'yes' => __( 'Yes', Postman::TEXT_DOMAIN ),
-				'no' => __( 'No', Postman::TEXT_DOMAIN ),
+				'in_progress' => _x( 'Checking..', 'The "please wait" message', 'post-smtp' ),
+				'open' => _x( 'Open', 'The port is open', 'post-smtp' ),
+				'closed' => _x( 'Closed', 'The port is closed', 'post-smtp' ),
+				'yes' => __( 'Yes', 'post-smtp' ),
+				'no' => __( 'No', 'post-smtp' ),
 			/* translators: where %d is a port number */
-			'blocked' => __( 'No outbound route between this site and the Internet on Port %d.', Postman::TEXT_DOMAIN ),
+			'blocked' => __( 'No outbound route between this site and the Internet on Port %d.', 'post-smtp' ),
 			/* translators: where %d is a port number and %s is a hostname */
-			'try_dif_smtp' => __( 'Port %d is open, but not to %s.', Postman::TEXT_DOMAIN ),
+			'try_dif_smtp' => __( 'Port %d is open, but not to %s.', 'post-smtp' ),
 			/* translators: where %d is the port number and %s is the hostname */
-			'success' => __( 'Port %d can be used for SMTP to %s.', Postman::TEXT_DOMAIN ),
-				'mitm' => sprintf( '%s: %s', __( 'Warning', Postman::TEXT_DOMAIN ), __( 'connected to %1$s instead of %2$s.', Postman::TEXT_DOMAIN ) ),
+			'success' => __( 'Port %d can be used for SMTP to %s.', 'post-smtp' ),
+				'mitm' => sprintf( '%s: %s', __( 'Warning', 'post-smtp' ), __( 'connected to %1$s instead of %2$s.', 'post-smtp' ) ),
 			/* translators: where %d is a port number and %s is the URL for the Postman Gmail Extension */
-			'https_success' => __( 'Port %d can be used with the %s.', Postman::TEXT_DOMAIN ),
+			'https_success' => __( 'Port %d can be used with the %s.', 'post-smtp' ),
 		) );
 	}
 
@@ -132,46 +132,46 @@ class PostmanConnectivityTestController {
 	public function outputPortTestContent() {
 		print '<div class="wrap">';
 
-		PostmanViewController::outputChildPageHeader( __( 'Connectivity Test', Postman::TEXT_DOMAIN ) );
+		PostmanViewController::outputChildPageHeader( __( 'Connectivity Test', 'post-smtp' ) );
 
 		print '<p>';
-		print __( 'This test determines which well-known ports are available for Postman to use.', Postman::TEXT_DOMAIN );
+		print __( 'This test determines which well-known ports are available for Postman to use.', 'post-smtp' );
 		print '<form id="port_test_form_id" method="post">';
-		printf( '<label for="hostname">%s</label>', __( 'Outgoing Mail Server Hostname', Postman::TEXT_DOMAIN ) );
+		printf( '<label for="hostname">%s</label>', __( 'Outgoing Mail Server Hostname', 'post-smtp' ) );
 		$this->port_test_hostname_callback();
-		submit_button( _x( 'Begin Test', 'Button Label', Postman::TEXT_DOMAIN ), 'primary', 'begin-port-test', true );
+		submit_button( _x( 'Begin Test', 'Button Label', 'post-smtp' ), 'primary', 'begin-port-test', true );
 		print '</form>';
 		print '<table id="connectivity_test_table">';
-		print sprintf( '<tr><th rowspan="2">%s</th><th rowspan="2">%s</th><th rowspan="2">%s</th><th rowspan="2">%s</th><th rowspan="2">%s</th><th colspan="5">%s</th></tr>', __( 'Transport', Postman::TEXT_DOMAIN ), _x( 'Socket', 'A socket is the network term for host and port together', Postman::TEXT_DOMAIN ), __( 'Status', Postman::TEXT_DOMAIN ) . '<sup>*</sup>', __( 'Service Available', Postman::TEXT_DOMAIN ), __( 'Server ID', Postman::TEXT_DOMAIN ), __( 'Authentication', Postman::TEXT_DOMAIN ) );
+		print sprintf( '<tr><th rowspan="2">%s</th><th rowspan="2">%s</th><th rowspan="2">%s</th><th rowspan="2">%s</th><th rowspan="2">%s</th><th colspan="5">%s</th></tr>', __( 'Transport', 'post-smtp' ), _x( 'Socket', 'A socket is the network term for host and port together', 'post-smtp' ), __( 'Status', 'post-smtp' ) . '<sup>*</sup>', __( 'Service Available', 'post-smtp' ), __( 'Server ID', 'post-smtp' ), __( 'Authentication', 'post-smtp' ) );
 		print sprintf( '<tr><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th></tr>', 'None', 'Login', 'Plain', 'CRAM-MD5', 'OAuth 2.0' );
 		$sockets = PostmanTransportRegistry::getInstance()->getSocketsForSetupWizardToProbe();
 		foreach ( $sockets as $socket ) {
 			if ( $socket ['smtp'] ) {
 				print sprintf( '<tr id="%s"><th class="name">%s</th><td class="socket">%s:%s</td><td class="firewall resettable">-</td><td class="service resettable">-</td><td class="reported_id resettable">-</td><td class="auth_none resettable">-</td><td class="auth_login resettable">-</td><td class="auth_plain resettable">-</td><td class="auth_crammd5 resettable">-</td><td class="auth_xoauth2 resettable">-</td></tr>', $socket ['id'], $socket ['transport_name'], $socket ['host'], $socket ['port'] );
 			} else {
-				print sprintf( '<tr id="%s"><th class="name">%s</th><td class="socket">%s:%s</td><td class="firewall resettable">-</td><td class="service resettable">-</td><td class="reported_id resettable">-</td><td colspan="5">%s</td></tr>', $socket ['id'], $socket ['transport_name'], $socket ['host'], $socket ['port'], __( 'n/a', Postman::TEXT_DOMAIN ) );
+				print sprintf( '<tr id="%s"><th class="name">%s</th><td class="socket">%s:%s</td><td class="firewall resettable">-</td><td class="service resettable">-</td><td class="reported_id resettable">-</td><td colspan="5">%s</td></tr>', $socket ['id'], $socket ['transport_name'], $socket ['host'], $socket ['port'], __( 'n/a', 'post-smtp' ) );
 			}
 		}
 		print '</table>';
 		/* Translators: Where %s is the name of the service providing Internet connectivity test */
-		printf( '<p class="portquiz" style="display:none; font-size:0.8em">* %s</p>', sprintf( __( 'According to %s', Postman::TEXT_DOMAIN ), '<a target="_blank" href="https://downor.me/portquiz.net">portquiz.net</a>' ) );
+		printf( '<p class="portquiz" style="display:none; font-size:0.8em">* %s</p>', sprintf( __( 'According to %s', 'post-smtp' ), '<a target="_blank" href="https://downor.me/portquiz.net">portquiz.net</a>' ) );
 		printf( '<p class="ajax-loader" style="display:none"><img src="%s"/></p>', plugins_url( 'post-smtp/style/ajax-loader.gif' ) );
 		print '<section id="conclusion" style="display:none">';
-		print sprintf( '<h3>%s:</h3>', __( 'Summary', Postman::TEXT_DOMAIN ) );
+		print sprintf( '<h3>%s:</h3>', __( 'Summary', 'post-smtp' ) );
 		print '<ol class="conclusion">';
 		print '</ol>';
 		print '</section>';
 		print '<section id="blocked-port-help" style="display:none">';
-		print sprintf( '<p><b>%s</b></p>', __( 'A test with <span style="color:red">"No"</span> Service Available indicates one or more of these issues:', Postman::TEXT_DOMAIN ) );
+		print sprintf( '<p><b>%s</b></p>', __( 'A test with <span style="color:red">"No"</span> Service Available indicates one or more of these issues:', 'post-smtp' ) );
 		print '<ol>';
-		printf( '<li>%s</li>', __( 'Your web host has placed a firewall between this site and the Internet', Postman::TEXT_DOMAIN ) );
-		printf( '<li>%s</li>', __( 'The SMTP hostname is wrong or the mail server does not provide service on this port', Postman::TEXT_DOMAIN ) );
+		printf( '<li>%s</li>', __( 'Your web host has placed a firewall between this site and the Internet', 'post-smtp' ) );
+		printf( '<li>%s</li>', __( 'The SMTP hostname is wrong or the mail server does not provide service on this port', 'post-smtp' ) );
 		/* translators: where (1) is the URL and (2) is the system */
-		$systemBlockMessage = __( 'Your <a href="%1$s">%2$s configuration</a> is preventing outbound connections', Postman::TEXT_DOMAIN );
+		$systemBlockMessage = __( 'Your <a href="%1$s">%2$s configuration</a> is preventing outbound connections', 'post-smtp' );
 		printf( '<li>%s</li>', sprintf( $systemBlockMessage, 'http://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen', 'PHP' ) );
 		printf( '<li>%s</li>', sprintf( $systemBlockMessage, 'http://wp-mix.com/disable-external-url-requests/', 'WordPress' ) );
 		print '</ol></p>';
-		print sprintf( '<p><b>%s</b></p>', __( 'If the issues above can not be resolved, your last option is to configure Postman to use an email account managed by your web host with an SMTP server managed by your web host.', Postman::TEXT_DOMAIN ) );
+		print sprintf( '<p><b>%s</b></p>', __( 'If the issues above can not be resolved, your last option is to configure Postman to use an email account managed by your web host with an SMTP server managed by your web host.', 'post-smtp' ) );
 		print '</section>';
 		print '</div>';
 	}

--- a/Postman/Postman-Controller/PostmanDashboardWidgetController.php
+++ b/Postman/Postman-Controller/PostmanDashboardWidgetController.php
@@ -54,7 +54,7 @@ if (! class_exists ( "PostmanDashboardWidgetController" )) {
 		public function addDashboardWidget() {
 			// only display to the widget to administrator
 			if (PostmanUtils::isAdmin ()) {
-				wp_add_dashboard_widget ( 'example_dashboard_widget', __ ( 'Postman SMTP', Postman::TEXT_DOMAIN ), array (
+				wp_add_dashboard_widget ( 'example_dashboard_widget', __ ( 'Postman SMTP', 'post-smtp' ), array (
 						$this,
 						'printDashboardWidget' 
 				) ); // Display function.
@@ -67,7 +67,7 @@ if (! class_exists ( "PostmanDashboardWidgetController" )) {
 		public function addNetworkDashboardWidget() {
 			// only display to the widget to administrator
 			if (PostmanUtils::isAdmin ()) {
-				wp_add_dashboard_widget ( 'example_dashboard_widget', __ ( 'Postman SMTP', Postman::TEXT_DOMAIN ), array (
+				wp_add_dashboard_widget ( 'example_dashboard_widget', __ ( 'Postman SMTP', 'post-smtp' ), array (
 						$this,
 						'printNetworkDashboardWidget' 
 				) ); // Display function.
@@ -78,8 +78,8 @@ if (! class_exists ( "PostmanDashboardWidgetController" )) {
 		 * Create the function to output the contents of our Dashboard Widget.
 		 */
 		public function printDashboardWidget() {
-			$goToSettings = sprintf ( '<a href="%s">%s</a>', PostmanUtils::getSettingsPageUrl (), __ ( 'Settings', Postman::TEXT_DOMAIN ) );
-			$goToEmailLog = sprintf ( '%s', _x ( 'Email Log', 'The log of Emails that have been delivered', Postman::TEXT_DOMAIN ) );
+			$goToSettings = sprintf ( '<a href="%s">%s</a>', PostmanUtils::getSettingsPageUrl (), __ ( 'Settings', 'post-smtp' ) );
+			$goToEmailLog = sprintf ( '%s', _x ( 'Email Log', 'The log of Emails that have been delivered', 'post-smtp' ) );
 			if ($this->options->isMailLoggingEnabled ()) {
 				$goToEmailLog = sprintf ( '<a href="%s">%s</a>', PostmanUtils::getEmailLogPageUrl (), $goToEmailLog );
 			}
@@ -92,16 +92,16 @@ if (! class_exists ( "PostmanDashboardWidgetController" )) {
 		 */
 		public function print_postman_status() {
 			if (! PostmanPreRequisitesCheck::isReady ()) {
-				printf ( '<p><span style="color:red">%s</span></p>', __ ( 'Error: Postman is missing a required PHP library.', Postman::TEXT_DOMAIN ) );
+				printf ( '<p><span style="color:red">%s</span></p>', __ ( 'Error: Postman is missing a required PHP library.', 'post-smtp' ) );
 			} else if ($this->wpMailBinder->isUnboundDueToException ()) {
-				printf ( '<p><span style="color:red">%s</span></p>', __ ( 'Postman: wp_mail has been declared by another plugin or theme, so you won\'t be able to use Postman until the conflict is resolved.', Postman::TEXT_DOMAIN ) );
+				printf ( '<p><span style="color:red">%s</span></p>', __ ( 'Postman: wp_mail has been declared by another plugin or theme, so you won\'t be able to use Postman until the conflict is resolved.', 'post-smtp' ) );
 			} else {
 				if ($this->options->getRunMode () != PostmanOptions::RUN_MODE_PRODUCTION) {
-					printf ( '<p><span style="background-color:yellow">%s</span></p>', __ ( 'Postman is in <em>non-Production</em> mode and is dumping all emails.', Postman::TEXT_DOMAIN ) );
+					printf ( '<p><span style="background-color:yellow">%s</span></p>', __ ( 'Postman is in <em>non-Production</em> mode and is dumping all emails.', 'post-smtp' ) );
 				} else if (PostmanTransportRegistry::getInstance ()->getSelectedTransport ()->isConfiguredAndReady ()) {
-					printf ( '<p class="wp-menu-image dashicons-before dashicons-email"> %s </p>', sprintf ( _n ( '<span style="color:green">Postman is configured</span> and has delivered <span style="color:green">%d</span> email.', '<span style="color:green">Postman is configured</span> and has delivered <span style="color:green">%d</span> emails.', PostmanState::getInstance ()->getSuccessfulDeliveries (), Postman::TEXT_DOMAIN ), PostmanState::getInstance ()->getSuccessfulDeliveries () ) );
+					printf ( '<p class="wp-menu-image dashicons-before dashicons-email"> %s </p>', sprintf ( _n ( '<span style="color:green">Postman is configured</span> and has delivered <span style="color:green">%d</span> email.', '<span style="color:green">Postman is configured</span> and has delivered <span style="color:green">%d</span> emails.', PostmanState::getInstance ()->getSuccessfulDeliveries (), 'post-smtp' ), PostmanState::getInstance ()->getSuccessfulDeliveries () ) );
 				} else {
-					printf ( '<p><span style="color:red">%s</span></p>', __ ( 'Postman is <em>not</em> configured and is mimicking out-of-the-box WordPress email delivery.', Postman::TEXT_DOMAIN ) );
+					printf ( '<p><span style="color:red">%s</span></p>', __ ( 'Postman is <em>not</em> configured and is mimicking out-of-the-box WordPress email delivery.', 'post-smtp' ) );
 				}
 				$currentTransport = PostmanTransportRegistry::getInstance ()->getActiveTransport ();
 				$deliveryDetails = $currentTransport->getDeliveryDetails ( $this->options );
@@ -113,7 +113,7 @@ if (! class_exists ( "PostmanDashboardWidgetController" )) {
 		 * Create the function to output the contents of our Dashboard Widget.
 		 */
 		public function printNetworkDashboardWidget() {
-			printf ( '<p class="wp-menu-image dashicons-before dashicons-email"> %s</p>', __ ( 'Postman is operating in per-site mode.', Postman::TEXT_DOMAIN ) );
+			printf ( '<p class="wp-menu-image dashicons-before dashicons-email"> %s</p>', __ ( 'Postman is operating in per-site mode.', 'post-smtp' ) );
 		}
 		
 		/**
@@ -143,7 +143,7 @@ if (! class_exists ( "PostmanDashboardWidgetController" )) {
 						$privated = intval ( $num_posts->private );
 						$post_type = get_post_type_object ( $type );
 						
-						$text = _n ( '%s ' . $post_type->labels->singular_name, '%s ' . $post_type->labels->name, $privated, Postman::TEXT_DOMAIN );
+						$text = _n ( '%s ' . $post_type->labels->singular_name, '%s ' . $post_type->labels->name, $privated, 'post-smtp' );
 						$text = sprintf ( $text, number_format_i18n ( $privated ) );
 						
 						$items [] = sprintf ( '<a class="%1$s-count" href="%3$s">%2$s</a>', $type, $text, PostmanUtils::getEmailLogPageUrl () ) . "\n";

--- a/Postman/Postman-Controller/PostmanWelcomeController.php
+++ b/Postman/Postman-Controller/PostmanWelcomeController.php
@@ -19,8 +19,8 @@ class PostmanWelcomeController {
 
 			// About
 			add_dashboard_page(
-				__( 'Welcome',  Postman::TEXT_DOMAIN ),
-				__( 'Welcome',  Postman::TEXT_DOMAIN ),
+				__( 'Welcome',  'post-smtp' ),
+				__( 'Welcome',  'post-smtp' ),
 				'manage_options',
 				'post-about',
 				array( $this, 'about_screen' )
@@ -28,8 +28,8 @@ class PostmanWelcomeController {
 
 			// Credits
 			add_dashboard_page(
-				__( 'Credits',  Postman::TEXT_DOMAIN ),
-				__( 'Credits',  Postman::TEXT_DOMAIN ),
+				__( 'Credits',  'post-smtp' ),
+				__( 'Credits',  'post-smtp' ),
 				'manage_options',
 				'post-credits',
 				array( $this, 'credits_screen' )
@@ -72,36 +72,36 @@ class PostmanWelcomeController {
 			}
 		</style>
 		<div class="wrap about-wrap">
-			<h1><?php printf( esc_html__( 'Welcome to Post SMTP %s', Postman::TEXT_DOMAIN ), $this->version ); ?></h1>
-			<div class="about-text"><?php printf( esc_html__( 'Thank you for updating! Post SMTP %s is bundled up and ready to take your SMTP needs to the next level!', Postman::TEXT_DOMAIN ), $this->version ); ?><br>
+			<h1><?php printf( esc_html__( 'Welcome to Post SMTP %s', 'post-smtp' ), $this->version ); ?></h1>
+			<div class="about-text"><?php printf( esc_html__( 'Thank you for updating! Post SMTP %s is bundled up and ready to take your SMTP needs to the next level!', 'post-smtp' ), $this->version ); ?><br>
 				<?php printf( '<strong>%s</strong>','Post SMTP support every SMTP service: Gmail/G-suite, SendGrid, Mandrill, Office365, and more...' ); ?>
 			</div>
-			<div class="post-badge"><?php printf( esc_html__( 'Version %s', Postman::TEXT_DOMAIN ), $this->version ); ?></div>
+			<div class="post-badge"><?php printf( esc_html__( 'Version %s', 'post-smtp' ), $this->version ); ?></div>
 
 			<h2 class="nav-tab-wrapper">
 				<a class="nav-tab nav-tab-active" href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'post-about' ), 'index.php' ) ) ); ?>">
-					<?php esc_html_e( 'What&#8217;s New', Postman::TEXT_DOMAIN ); ?>
+					<?php esc_html_e( 'What&#8217;s New', 'post-smtp' ); ?>
 				</a><a class="nav-tab" href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'post-credits' ), 'index.php' ) ) ); ?>">
-					<?php esc_html_e( 'Credits', Postman::TEXT_DOMAIN ); ?>
+					<?php esc_html_e( 'Credits', 'post-smtp' ); ?>
 				</a>
 			</h2>
 
 			<div class="changelog">
-				<h3><?php esc_html_e( 'Email Log', Postman::TEXT_DOMAIN ); ?></h3>
+				<h3><?php esc_html_e( 'Email Log', 'post-smtp' ); ?></h3>
 
 				<div class="feature-section col two-col">
 					<div class="last-feature">
-						<h4><?php esc_html_e( 'Email log filter', Postman::TEXT_DOMAIN ); ?></h4>
+						<h4><?php esc_html_e( 'Email log filter', 'post-smtp' ); ?></h4>
 						<p>
-							<?php esc_html_e( 'You can easily filter by dates and search in your log.', Postman::TEXT_DOMAIN ); ?>
+							<?php esc_html_e( 'You can easily filter by dates and search in your log.', 'post-smtp' ); ?>
 							<img src="<?php echo $this->pluginUrl; ?>/images/filter-preview.gif">	
 						</p>
 					</div>
 
 					<div>
-						<h4><?php esc_html_e( 'Multiple emails resend', Postman::TEXT_DOMAIN ); ?></h4>
+						<h4><?php esc_html_e( 'Multiple emails resend', 'post-smtp' ); ?></h4>
 						<p>
-							<?php esc_html_e( 'Resend any email to the original recipient or any other emails you choose.', Postman::TEXT_DOMAIN ); ?>
+							<?php esc_html_e( 'Resend any email to the original recipient or any other emails you choose.', 'post-smtp' ); ?>
 							<img src="<?php echo $this->pluginUrl; ?>/images/resend-preview.gif">	
 						</p>
 					</div>
@@ -109,7 +109,7 @@ class PostmanWelcomeController {
 			</div>
 
 			<div class="changelog">
-				<h3><?php esc_html_e( 'The best delivery experience', Postman::TEXT_DOMAIN ); ?></h3>
+				<h3><?php esc_html_e( 'The best delivery experience', 'post-smtp' ); ?></h3>
 
 				<div class="feature-section col one-col">
 					<div class="last-feature">
@@ -120,30 +120,30 @@ class PostmanWelcomeController {
 						Supports forced recipients (cc, bcc, to) and custom email headers,
 						SASL Support: Plain/Login/CRAM-MD5/XOAUTH2 authentication,
 						Security Support: SMTPS and STARTTLS (SSL/TLS),
-						Copy configuration to other instances of Post.', Postman::TEXT_DOMAIN ); ?></p>
+						Copy configuration to other instances of Post.', 'post-smtp' ); ?></p>
 					</div>
 				</div>
 
 				<div class="feature-section col three-col">
 					<div>
-						<h4><?php esc_html_e( 'Email log HTML preview', Postman::TEXT_DOMAIN ); ?></h4>
-						<p><?php esc_html_e( 'You can now see sent emails as HTML.', Postman::TEXT_DOMAIN ); ?></p>
+						<h4><?php esc_html_e( 'Email log HTML preview', 'post-smtp' ); ?></h4>
+						<p><?php esc_html_e( 'You can now see sent emails as HTML.', 'post-smtp' ); ?></p>
 					</div>
 
 					<div>
-						<h4><?php esc_html_e( 'Continues email delivery', Postman::TEXT_DOMAIN ); ?></h4>
-						<p><?php esc_html_e( 'if email fail to sent you will get notified using the local mail system.', Postman::TEXT_DOMAIN ); ?></p>
+						<h4><?php esc_html_e( 'Continues email delivery', 'post-smtp' ); ?></h4>
+						<p><?php esc_html_e( 'if email fail to sent you will get notified using the local mail system.', 'post-smtp' ); ?></p>
 					</div>
 
 					<div class="last-feature">
-						<h4><?php esc_html_e( 'The best debugging tools.', Postman::TEXT_DOMAIN ); ?></h4>
-						<p><?php esc_html_e( 'Full Transcripts, Connectivity Test, Diagnostic Test.', Postman::TEXT_DOMAIN ); ?></p>
+						<h4><?php esc_html_e( 'The best debugging tools.', 'post-smtp' ); ?></h4>
+						<p><?php esc_html_e( 'Full Transcripts, Connectivity Test, Diagnostic Test.', 'post-smtp' ); ?></p>
 					</div>
 				</div>
 			</div>
 
 			<div class="return-to-dashboard">
-				<a href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'postman' ), 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Go to Post SMTP Settings', Postman::TEXT_DOMAIN ); ?></a>
+				<a href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'postman' ), 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Go to Post SMTP Settings', 'post-smtp' ); ?></a>
 			</div>
 
 		</div>
@@ -170,36 +170,36 @@ class PostmanWelcomeController {
 			}			
 		</style>
 		<div class="wrap about-wrap">
-			<h1><?php printf( esc_html__( 'Welcome to Post SMTP %s', Postman::TEXT_DOMAIN ), $this->version ); ?></h1>
-			<div class="about-text"><?php printf( esc_html__( 'Thank you for updating! bbPress %s is waxed, polished, and ready for you to take it for a lap or two around the block!', Postman::TEXT_DOMAIN ), $this->version ); ?></div>
-			<div class="post-badge"><?php printf( esc_html__( 'Version %s', Postman::TEXT_DOMAIN ), $this->version ); ?></div>
+			<h1><?php printf( esc_html__( 'Welcome to Post SMTP %s', 'post-smtp' ), $this->version ); ?></h1>
+			<div class="about-text"><?php printf( esc_html__( 'Thank you for updating! bbPress %s is waxed, polished, and ready for you to take it for a lap or two around the block!', 'post-smtp' ), $this->version ); ?></div>
+			<div class="post-badge"><?php printf( esc_html__( 'Version %s', 'post-smtp' ), $this->version ); ?></div>
 
 			<h2 class="nav-tab-wrapper">
 				<a href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'post-about' ), 'index.php' ) ) ); ?>" class="nav-tab">
-					<?php esc_html_e( 'What&#8217;s New', Postman::TEXT_DOMAIN ); ?>
+					<?php esc_html_e( 'What&#8217;s New', 'post-smtp' ); ?>
 				</a><a href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'post-credits' ), 'index.php' ) ) ); ?>" class="nav-tab nav-tab-active">
-					<?php esc_html_e( 'Credits', Postman::TEXT_DOMAIN ); ?>
+					<?php esc_html_e( 'Credits', 'post-smtp' ); ?>
 				</a>
 			</h2>
 
-			<p class="about-description"><?php esc_html_e( 'Post SMTP started by Jason Hendriks, Jason left the project and Yehuda Hassine (me) continue his work.', Postman::TEXT_DOMAIN ); ?></p>
+			<p class="about-description"><?php esc_html_e( 'Post SMTP started by Jason Hendriks, Jason left the project and Yehuda Hassine (me) continue his work.', 'post-smtp' ); ?></p>
 
-			<h4 class="wp-people-group"><?php esc_html_e( 'Project Leaders', Postman::TEXT_DOMAIN ); ?></h4>
+			<h4 class="wp-people-group"><?php esc_html_e( 'Project Leaders', 'post-smtp' ); ?></h4>
 			<ul class="wp-people-group " id="wp-people-group-project-leaders">
 				<li class="wp-person" id="wp-person-jasonhendriks">
 					<a href="https://profiles.wordpress.org/jasonhendriks"><img src="https://secure.gravatar.com/avatar/8692c7b6084517a592f6cad107f7bcb0?s=60&d=mm&r=g" class="gravatar" alt="Jason Hendriks " /></a>
 					<a class="web" href="http://profiles.wordpress.org/matt">Jason Hendriks</a>
-					<span class="title"><?php esc_html_e( 'Founding Developer (abandoned)', Postman::TEXT_DOMAIN ); ?></span>
+					<span class="title"><?php esc_html_e( 'Founding Developer (abandoned)', 'post-smtp' ); ?></span>
 				</li>
 				<li class="wp-person" id="wp-person-yehudah">
 					<a href="http://profiles.wordpress.org/yehudah"><img src="https://secure.gravatar.com/avatar/c561638d04ea8fef351f974dbb9ece39?s=60&d=mm&r=g" class="gravatar" alt="Yehuda Hassine" /></a>
 					<a class="web" href="http://profiles.wordpress.org/yehudah">Yehuda Hassine</a>
-					<span class="title"><?php esc_html_e( 'Lead Developer', Postman::TEXT_DOMAIN ); ?></span>
+					<span class="title"><?php esc_html_e( 'Lead Developer', 'post-smtp' ); ?></span>
 				</li>
 			</ul>
 
-			<h4 class="wp-people-group"><?php esc_html_e( 'Top Community Members', Postman::TEXT_DOMAIN ); ?></h4>
-			<h5><?php esc_html_e( 'Here I will list top users that help Post SMTP grow (bugs, features, etc...)', Postman::TEXT_DOMAIN ); ?>
+			<h4 class="wp-people-group"><?php esc_html_e( 'Top Community Members', 'post-smtp' ); ?></h4>
+			<h5><?php esc_html_e( 'Here I will list top users that help Post SMTP grow (bugs, features, etc...)', 'post-smtp' ); ?>
 			<p class="wp-credits-list">
 				<a href="http://profiles.wordpress.org/diegocanal">diegocanal</a>,
 				<a href="http://profiles.wordpress.org/jyourstone">Johan Yourstone</a>,
@@ -209,7 +209,7 @@ class PostmanWelcomeController {
 			</p>
 
 			<div class="return-to-dashboard">
-				<a href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'postman' ), 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Go to Post SMTP Settings', Postman::TEXT_DOMAIN ); ?></a>
+				<a href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'postman' ), 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Go to Post SMTP Settings', 'post-smtp' ); ?></a>
 			</div>
 
 		</div>

--- a/Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php
+++ b/Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php
@@ -77,7 +77,7 @@ class PostmanDiagnosticTestController {
 	 * Register the Diagnostics screen
 	 */
 	public function addDiagnosticsSubmenu() {
-		$page = add_submenu_page( null, sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ) ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanDiagnosticTestController::DIAGNOSTICS_SLUG, array(
+		$page = add_submenu_page( null, sprintf( __( '%s Setup', 'post-smtp' ), __( 'Postman SMTP', 'post-smtp' ) ), __( 'Postman SMTP', 'post-smtp' ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanDiagnosticTestController::DIAGNOSTICS_SLUG, array(
 				$this,
 				'outputDiagnosticsContent',
 		) );
@@ -98,14 +98,14 @@ class PostmanDiagnosticTestController {
 		// test features
 		print '<div class="wrap">';
 
-		PostmanViewController::outputChildPageHeader( __( 'Diagnostic Test', Postman::TEXT_DOMAIN ) );
+		PostmanViewController::outputChildPageHeader( __( 'Diagnostic Test', 'post-smtp' ) );
 
-		printf( '<h4>%s</h4>', __( 'Are you having issues with Postman?', Postman::TEXT_DOMAIN ) );
+		printf( '<h4>%s</h4>', __( 'Are you having issues with Postman?', 'post-smtp' ) );
 		/* translators: where %1$s and %2$s are the URLs to the Troubleshooting and Support Forums on WordPress.org */
-		printf( '<p style="margin:0 10px">%s</p>', sprintf( __( 'Please check the <a href="%1$s">troubleshooting and error messages</a> page and the <a href="%2$s">support forum</a>.', Postman::TEXT_DOMAIN ), 'https://wordpress.org/plugins/post-smtp/other_notes/', 'https://wordpress.org/support/plugin/post-smtp' ) );
-		printf( '<h4>%s</h4>', __( 'Diagnostic Test', Postman::TEXT_DOMAIN ) );
-		printf( '<p style="margin:0 10px">%s</p><br/>', sprintf( __( 'If you write for help, please include the following:', Postman::TEXT_DOMAIN ), 'https://wordpress.org/plugins/post-smtp/other_notes/', 'https://wordpress.org/support/plugin/post-smtp' ) );
-		printf( '<textarea readonly="readonly" id="diagnostic-text" cols="80" rows="15">%s</textarea>', _x( 'Checking..', 'The "please wait" message', Postman::TEXT_DOMAIN ) );
+		printf( '<p style="margin:0 10px">%s</p>', sprintf( __( 'Please check the <a href="%1$s">troubleshooting and error messages</a> page and the <a href="%2$s">support forum</a>.', 'post-smtp' ), 'https://wordpress.org/plugins/post-smtp/other_notes/', 'https://wordpress.org/support/plugin/post-smtp' ) );
+		printf( '<h4>%s</h4>', __( 'Diagnostic Test', 'post-smtp' ) );
+		printf( '<p style="margin:0 10px">%s</p><br/>', sprintf( __( 'If you write for help, please include the following:', 'post-smtp' ), 'https://wordpress.org/plugins/post-smtp/other_notes/', 'https://wordpress.org/support/plugin/post-smtp' ) );
+		printf( '<textarea readonly="readonly" id="diagnostic-text" cols="80" rows="15">%s</textarea>', _x( 'Checking..', 'The "please wait" message', 'post-smtp' ) );
 		print '</div>';
 	}
 }

--- a/Postman/Postman-Email-Log/PostmanEmailLogController.php
+++ b/Postman/Postman-Email-Log/PostmanEmailLogController.php
@@ -97,7 +97,7 @@ class PostmanEmailLogController {
 			if ( $success ) {
 				$this->logger->debug( 'Email was successfully re-sent' );
 				// the message was sent successfully, generate an appropriate message for the user
-				$statusMessage = sprintf( __( 'Your message was delivered (%d ms) to the SMTP server! Congratulations :)', Postman::TEXT_DOMAIN ), $result ['time'] );
+				$statusMessage = sprintf( __( 'Your message was delivered (%d ms) to the SMTP server! Congratulations :)', 'post-smtp' ), $result ['time'] );
 
 				// compose the JSON response for the caller
 				$response = array(
@@ -163,7 +163,7 @@ class PostmanEmailLogController {
 						$purger->verifyLogItemExistsAndRemove( $postid );
 					}
 					$mh = new PostmanMessageHandler();
-					$mh->addMessage( __( 'Mail Log Entries were deleted.', Postman::TEXT_DOMAIN ) );
+					$mh->addMessage( __( 'Mail Log Entries were deleted.', 'post-smtp' ) );
 				} else {
 					$this->logger->warn( sprintf( 'action "%s" not recognized', $_REQUEST ['action'] ) );
 				}
@@ -186,7 +186,7 @@ class PostmanEmailLogController {
 				$purger = new PostmanEmailLogPurger();
 				$purger->verifyLogItemExistsAndRemove( $postid );
 				$mh = new PostmanMessageHandler();
-				$mh->addMessage( __( 'Mail Log Entry was deleted.', Postman::TEXT_DOMAIN ) );
+				$mh->addMessage( __( 'Mail Log Entry was deleted.', 'post-smtp' ) );
 			} else {
 				$this->logger->warn( sprintf( 'nonce "%s" failed validation', $_REQUEST ['_wpnonce'] ) );
 			}
@@ -211,29 +211,29 @@ class PostmanEmailLogController {
 }</style></head><body>';
 			print '<table>';
 			if ( ! empty( $meta_values ['from_header'] [0] ) ) {
-				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'From', 'Who is this message From?', Postman::TEXT_DOMAIN ), esc_html( $meta_values ['from_header'] [0] ) );
+				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'From', 'Who is this message From?', 'post-smtp' ), esc_html( $meta_values ['from_header'] [0] ) );
 			}
 			// show the To header (it's optional)
 			if ( ! empty( $meta_values ['to_header'] [0] ) ) {
-				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'To', 'Who is this message To?', Postman::TEXT_DOMAIN ), esc_html( $meta_values ['to_header'] [0] ) );
+				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'To', 'Who is this message To?', 'post-smtp' ), esc_html( $meta_values ['to_header'] [0] ) );
 			}
 			// show the Cc header (it's optional)
 			if ( ! empty( $meta_values ['cc_header'] [0] ) ) {
-				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Cc', 'Who is this message Cc\'d to?', Postman::TEXT_DOMAIN ), esc_html( $meta_values ['cc_header'] [0] ) );
+				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Cc', 'Who is this message Cc\'d to?', 'post-smtp' ), esc_html( $meta_values ['cc_header'] [0] ) );
 			}
 			// show the Bcc header (it's optional)
 			if ( ! empty( $meta_values ['bcc_header'] [0] ) ) {
-				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Bcc', 'Who is this message Bcc\'d to?', Postman::TEXT_DOMAIN ), esc_html( $meta_values ['bcc_header'] [0] ) );
+				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Bcc', 'Who is this message Bcc\'d to?', 'post-smtp' ), esc_html( $meta_values ['bcc_header'] [0] ) );
 			}
 			// show the Reply-To header (it's optional)
 			if ( ! empty( $meta_values ['reply_to_header'] [0] ) ) {
-				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', __( 'Reply-To', Postman::TEXT_DOMAIN ), esc_html( $meta_values ['reply_to_header'] [0] ) );
+				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', __( 'Reply-To', 'post-smtp' ), esc_html( $meta_values ['reply_to_header'] [0] ) );
 			}
-			printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Date', 'What is the date today?', Postman::TEXT_DOMAIN ), $post->post_date );
-			printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Subject', 'What is the subject of this message?', Postman::TEXT_DOMAIN ), esc_html( $post->post_title ) );
+			printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Date', 'What is the date today?', 'post-smtp' ), $post->post_date );
+			printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Subject', 'What is the subject of this message?', 'post-smtp' ), esc_html( $post->post_title ) );
 			// The Transport UI is always there, in more recent versions that is
 			if ( ! empty( $meta_values ['transport_uri'] [0] ) ) {
-				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Delivery-URI', 'What is the unique URI of the configuration?', Postman::TEXT_DOMAIN ), esc_html( $meta_values ['transport_uri'] [0] ) );
+				printf( '<tr><th style="text-align:right">%s:</th><td>%s</td></tr>', _x( 'Delivery-URI', 'What is the unique URI of the configuration?', 'post-smtp' ), esc_html( $meta_values ['transport_uri'] [0] ) );
 			}
 			print '</table>';
 			print '<hr/>';
@@ -267,14 +267,14 @@ class PostmanEmailLogController {
     border-bottom: 1px dashed #ccc;
     background: #bbb;
 }</style></head><body>';
-			printf( '<p>%s</p>', __( 'This is the conversation between Postman and the mail server. It can be useful for diagnosing problems. <b>DO NOT</b> post it on-line, it may contain your account password.', Postman::TEXT_DOMAIN ) );
+			printf( '<p>%s</p>', __( 'This is the conversation between Postman and the mail server. It can be useful for diagnosing problems. <b>DO NOT</b> post it on-line, it may contain your account password.', 'post-smtp' ) );
 			print '<hr/>';
 			print '<pre>';
 			if ( ! empty( $meta_values ['session_transcript'] [0] ) ) {
 				print esc_html( $meta_values ['session_transcript'] [0] );
 			} else {
 				/* Translators: Meaning "Not Applicable" */
-				print __( 'n/a', Postman::TEXT_DOMAIN );
+				print __( 'n/a', 'post-smtp' );
 			}
 			print '</pre>';
 			print '</body></html>';
@@ -299,8 +299,8 @@ class PostmanEmailLogController {
 			$this->logger->trace( 'created PostmanEmailLog admin menu item' );
 			/*
 			Translators where (%s) is the name of the plugin */
-			$pageTitle = sprintf( __( '%s Email Log', Postman::TEXT_DOMAIN ), __( 'Post SMTP', Postman::TEXT_DOMAIN ) );
-			$pluginName = _x( 'Email Log', 'The log of Emails that have been delivered', Postman::TEXT_DOMAIN );
+			$pageTitle = sprintf( __( '%s Email Log', 'post-smtp' ), __( 'Post SMTP', 'post-smtp' ) );
+			$pluginName = _x( 'Email Log', 'The log of Emails that have been delivered', 'post-smtp' );
 
 			$page = add_submenu_page( PostmanViewController::POSTMAN_MENU_SLUG, $pageTitle, $pluginName, Postman::MANAGE_POSTMAN_CAPABILITY_LOGS, 'postman_email_log', array( $this, 'postman_render_email_page' ) );
 
@@ -317,10 +317,10 @@ class PostmanEmailLogController {
 		wp_enqueue_style( 'postman_email_log' );
 		wp_enqueue_script( 'postman_resend_email_script' );
 		wp_enqueue_script( 'sprintf' );
-		wp_localize_script( 'postman_resend_email_script', 'postman_js_email_was_resent', __( 'Email was successfully resent (but without attachments)', Postman::TEXT_DOMAIN ) );
+		wp_localize_script( 'postman_resend_email_script', 'postman_js_email_was_resent', __( 'Email was successfully resent (but without attachments)', 'post-smtp' ) );
 		/* Translators: Where %s is an error message */
-		wp_localize_script( 'postman_resend_email_script', 'postman_js_email_not_resent', __( 'Email could not be resent. Error: %s', Postman::TEXT_DOMAIN ) );
-		wp_localize_script( 'postman_resend_email_script', 'postman_js_resend_label', __( 'Resend', Postman::TEXT_DOMAIN ) );
+		wp_localize_script( 'postman_resend_email_script', 'postman_js_email_not_resent', __( 'Email could not be resent. Error: %s', 'post-smtp' ) );
+		wp_localize_script( 'postman_resend_email_script', 'postman_js_resend_label', __( 'Resend', 'post-smtp' ) );
 	}
 
 	/**
@@ -349,13 +349,13 @@ class PostmanEmailLogController {
 	</div>
 	<h2><?php
 	/* Translators where (%s) is the name of the plugin */
-		echo sprintf( __( '%s Email Log', Postman::TEXT_DOMAIN ), __( 'Post SMTP', Postman::TEXT_DOMAIN ) )?></h2>
+		echo sprintf( __( '%s Email Log', 'post-smtp' ), __( 'Post SMTP', 'post-smtp' ) )?></h2>
 
 	<div
 		style="background: #ECECEC; border: 1px solid #CCC; padding: 0 10px; margin-top: 5px; border-radius: 5px; -moz-border-radius: 5px; -webkit-border-radius: 5px;">
 		<p><?php
 
-		echo __( 'This is a record of deliveries made to the mail server. It does not neccessarily indicate sucessful delivery to the recipient.', Postman::TEXT_DOMAIN )?></p>
+		echo __( 'This is a record of deliveries made to the mail server. It does not neccessarily indicate sucessful delivery to the recipient.', 'post-smtp' )?></p>
 	</div>
 
 	<?php
@@ -369,19 +369,19 @@ class PostmanEmailLogController {
 	<form id="postman-email-log-filter" method="post">
 		<div id="email-log-filter" class="postman-log-row">
 			<div class="form-control">
-				<label for="from_date"><?php _e( 'From Date', Postman::TEXT_DOMAIN ); ?></label>
-				<input id="from_date" class="email-log-date" value="<?php echo $from_date; ?>" type="text" name="from_date" placeholder="<?php _e( 'From Date', Postman::TEXT_DOMAIN ); ?>">
+				<label for="from_date"><?php _e( 'From Date', 'post-smtp' ); ?></label>
+				<input id="from_date" class="email-log-date" value="<?php echo $from_date; ?>" type="text" name="from_date" placeholder="<?php _e( 'From Date', 'post-smtp' ); ?>">
 			</div>
 			<div class="form-control">
-				<label for="to_date"><?php _e( 'To Date', Postman::TEXT_DOMAIN ); ?></label>		
-				<input id="to_date" class="email-log-date" value="<?php echo $to_date; ?>" type="text" name="to_date" placeholder="<?php _e( 'To Date', Postman::TEXT_DOMAIN ); ?>">
+				<label for="to_date"><?php _e( 'To Date', 'post-smtp' ); ?></label>		
+				<input id="to_date" class="email-log-date" value="<?php echo $to_date; ?>" type="text" name="to_date" placeholder="<?php _e( 'To Date', 'post-smtp' ); ?>">
 			</div>
 			<div class="form-control">
-				<label for="search"><?php _e( 'Search', Postman::TEXT_DOMAIN ); ?></label>		
-				<input id="search" type="text" name="search" value="<?php echo $search; ?>" placeholder="<?php _e( 'Search', Postman::TEXT_DOMAIN ); ?>">
+				<label for="search"><?php _e( 'Search', 'post-smtp' ); ?></label>		
+				<input id="search" type="text" name="search" value="<?php echo $search; ?>" placeholder="<?php _e( 'Search', 'post-smtp' ); ?>">
 			</div>
 			<div class="form-control">
-				<label id="postman_page_records"><?php _e( 'Records per page', Postman::TEXT_DOMAIN ); ?></label>
+				<label id="postman_page_records"><?php _e( 'Records per page', 'post-smtp' ); ?></label>
 				<select id="postman_page_records" name="postman_page_records">
 					<?php
 					foreach ( $page_records as $value ) {
@@ -392,10 +392,10 @@ class PostmanEmailLogController {
 				</select>	
 			</div>		
 			<div class="form-control" style="padding: 0 5px 0 5px;">
-				<button type="submit" name="filter" class="button button-primary"><?php _e( 'Filter/Search', Postman::TEXT_DOMAIN ); ?></button>
+				<button type="submit" name="filter" class="button button-primary"><?php _e( 'Filter/Search', 'post-smtp' ); ?></button>
 			</div>	
 			<div class="form-control">
-				<button type="submit" id="postman_trash_all" name="postman_trash_all" class="button button-primary"><?php _e( 'Trash All', Postman::TEXT_DOMAIN ); ?></button>
+				<button type="submit" id="postman_trash_all" name="postman_trash_all" class="button button-primary"><?php _e( 'Trash All', 'post-smtp' ); ?></button>
 			</div>			
 		</div>
 		<div class="error">Please notice: when you select a date for example 11/20/2017, behind the scene the query select <b>11/20/2017 00:00:00</b>.<br>So if you searching for an email arrived that day at any hour you need to select 11/20/2017 as the <b>From Date</b> and 11/21/2017 as the <b>To Date</b>.</div>

--- a/Postman/Postman-Email-Log/PostmanEmailLogPostType.php
+++ b/Postman/Postman-Email-Log/PostmanEmailLogPostType.php
@@ -34,8 +34,8 @@ if (! class_exists ( 'PostmanEmailLogPostType' )) {
 		public static function create_post_type() {
 			register_post_type ( self::POSTMAN_CUSTOM_POST_TYPE_SLUG, array (
 					'labels' => array (
-							'name' => _x ( 'Sent Emails', 'The group of Emails that have been delivered', Postman::TEXT_DOMAIN ),
-							'singular_name' => _x ( 'Sent Email', 'An Email that has been delivered', Postman::TEXT_DOMAIN ) 
+							'name' => _x ( 'Sent Emails', 'The group of Emails that have been delivered', 'post-smtp' ),
+							'singular_name' => _x ( 'Sent Email', 'An Email that has been delivered', 'post-smtp' ) 
 					),
 					'capability_type' => '',
 					'capabilities' => array () 

--- a/Postman/Postman-Email-Log/PostmanEmailLogService.php
+++ b/Postman/Postman-Email-Log/PostmanEmailLogService.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'PostmanEmailLogService' ) ) {
 				$status = true;
 				$subject = $message->getSubject();
 				if ( empty( $subject ) ) {
-					$statusMessage = sprintf( '%s: %s', __( 'Warning', Postman::TEXT_DOMAIN ), __( 'An empty subject line can result in delivery failure.', Postman::TEXT_DOMAIN ) );
+					$statusMessage = sprintf( '%s: %s', __( 'Warning', 'post-smtp' ), __( 'An empty subject line can result in delivery failure.', 'post-smtp' ) );
 					$status = 'WARN';
 				}
 				$this->createLog( $log, $message, $transcript, $statusMessage, $status, $transport );
@@ -182,9 +182,9 @@ if ( ! class_exists( 'PostmanEmailLogService' ) ) {
 		}
 
 		private function checkForLogErrors( PostmanEmailLog $log, $postMessage ) {
-			$message = __( 'You getting this message because an error detected while delivered your email.', Postman::TEXT_DOMAIN );
-			$message .= "\r\n" . sprintf( __( 'For the domain: %1$s',Postman::TEXT_DOMAIN ), get_bloginfo('url') );
-			$message .= "\r\n" . __( 'The log to paste when you open a support issue:', Postman::TEXT_DOMAIN ) . "\r\n";
+			$message = __( 'You getting this message because an error detected while delivered your email.', 'post-smtp' );
+			$message .= "\r\n" . sprintf( __( 'For the domain: %1$s','post-smtp' ), get_bloginfo('url') );
+			$message .= "\r\n" . __( 'The log to paste when you open a support issue:', 'post-smtp' ) . "\r\n";
 
 			if ( $log->statusMessage && ! empty( $log->statusMessage ) ) {
 				require_once POST_PATH . '/Postman/notifications/PostmanNotify.php';
@@ -263,7 +263,7 @@ if ( ! class_exists( 'PostmanEmailLogService' ) ) {
 			$count = 0;
 			foreach ( $addresses as $address ) {
 				if ( $count >= 3 ) {
-					$flat .= sprintf( __( '.. +%d more', Postman::TEXT_DOMAIN ), sizeof( $addresses ) - $count );
+					$flat .= sprintf( __( '.. +%d more', 'post-smtp' ), sizeof( $addresses ) - $count );
 					break;
 				}
 				if ( $count > 0 ) {

--- a/Postman/Postman-Email-Log/PostmanEmailLogView.php
+++ b/Postman/Postman-Email-Log/PostmanEmailLogView.php
@@ -95,22 +95,22 @@ class PostmanEmailLogView extends WP_List_Table {
 		$meta_values = get_post_meta( $item ['ID'] );
 
 		$actions = array(
-				'delete' => sprintf( '<a href="%s">%s</a>', $deleteUrl, _x( 'Delete', 'Delete an item from the email log', Postman::TEXT_DOMAIN ) ),
-				'view' => sprintf( '<a href="%s" class="thickbox">%s</a>', $viewUrl, _x( 'View', 'View an item from the email log', Postman::TEXT_DOMAIN ) ),
+				'delete' => sprintf( '<a href="%s">%s</a>', $deleteUrl, _x( 'Delete', 'Delete an item from the email log', 'post-smtp' ) ),
+				'view' => sprintf( '<a href="%s" class="thickbox">%s</a>', $viewUrl, _x( 'View', 'View an item from the email log', 'post-smtp' ) ),
 		);
 
 		if ( ! empty( $meta_values ['session_transcript'] [0] ) ) {
-			$actions ['transcript'] = sprintf( '<a href="%1$s" class="thickbox">%2$s</a>', $transcriptUrl, __( 'Session Transcript', Postman::TEXT_DOMAIN ) );
+			$actions ['transcript'] = sprintf( '<a href="%1$s" class="thickbox">%2$s</a>', $transcriptUrl, __( 'Session Transcript', 'post-smtp' ) );
 		} else {
-			$actions ['transcript'] = sprintf( '%2$s', $transcriptUrl, __( 'Session Transcript', Postman::TEXT_DOMAIN ) );
+			$actions ['transcript'] = sprintf( '%2$s', $transcriptUrl, __( 'Session Transcript', 'post-smtp' ) );
 		}
 		if ( ! (empty( $meta_values ['original_to'] [0] ) && empty( $meta_values ['originalHeaders'] [0] )) ) {
-			// $actions ['resend'] = sprintf ( '<a href="%s">%s</a>', $resendUrl, __ ( 'Resend', Postman::TEXT_DOMAIN ) );
+			// $actions ['resend'] = sprintf ( '<a href="%s">%s</a>', $resendUrl, __ ( 'Resend', 'post-smtp' ) );
 			$emails = maybe_unserialize( $meta_values ['original_to'] [0] );
 			$to = is_array( $emails ) ? implode( ',', $emails ) : $emails;
-			$actions ['resend'] = sprintf( '<span id="%3$s"><a class="postman-open-resend" href="#">%2$s</a></span><div style="display:none;"><input type="hidden" name="security" value="%6$s"><input type="text" name="mail_to" class="regular-text ltr" data-id="%1$s" value="%4$s"><button class="postman-resend button button-primary">%2$s</button><i style="color: black;">%5$s</i></div>', $item ['ID'], __( 'Resend', Postman::TEXT_DOMAIN ), 'resend-' . $item ['ID'], esc_attr( $to ), __( 'comma-separated for multiple emails', Postman::TEXT_DOMAIN ), wp_create_nonce( 'resend' ) );
+			$actions ['resend'] = sprintf( '<span id="%3$s"><a class="postman-open-resend" href="#">%2$s</a></span><div style="display:none;"><input type="hidden" name="security" value="%6$s"><input type="text" name="mail_to" class="regular-text ltr" data-id="%1$s" value="%4$s"><button class="postman-resend button button-primary">%2$s</button><i style="color: black;">%5$s</i></div>', $item ['ID'], __( 'Resend', 'post-smtp' ), 'resend-' . $item ['ID'], esc_attr( $to ), __( 'comma-separated for multiple emails', 'post-smtp' ), wp_create_nonce( 'resend' ) );
 		} else {
-			$actions ['resend'] = sprintf( '%2$s', $resendUrl, __( 'Resend', Postman::TEXT_DOMAIN ) );
+			$actions ['resend'] = sprintf( '%2$s', $resendUrl, __( 'Resend', 'post-smtp' ) );
 		}
 
 		// Return the title contents
@@ -159,10 +159,10 @@ class PostmanEmailLogView extends WP_List_Table {
 	function get_columns() {
 		$columns = array(
 				'cb' => '<input type="checkbox" />', // Render a checkbox instead of text
-				'title' => _x( 'Subject', 'What is the subject of this message?', Postman::TEXT_DOMAIN ),
-				'sent_to' => __( 'Sent To', Postman::TEXT_DOMAIN ),
-				'status' => __( 'Status', Postman::TEXT_DOMAIN ),
-				'date' => _x( 'Delivery Time', 'When was this email sent?', Postman::TEXT_DOMAIN ),
+				'title' => _x( 'Subject', 'What is the subject of this message?', 'post-smtp' ),
+				'sent_to' => __( 'Sent To', 'post-smtp' ),
+				'status' => __( 'Status', 'post-smtp' ),
+				'date' => _x( 'Delivery Time', 'When was this email sent?', 'post-smtp' ),
 		);
 		return $columns;
 	}
@@ -222,7 +222,7 @@ class PostmanEmailLogView extends WP_List_Table {
 	 */
 	function get_bulk_actions() {
 		$actions = array(
-				'bulk_delete' => _x( 'Delete', 'Delete an item from the email log', Postman::TEXT_DOMAIN ),
+				'bulk_delete' => _x( 'Delete', 'Delete an item from the email log', 'post-smtp' ),
 		);
 		return $actions;
 	}
@@ -363,7 +363,7 @@ class PostmanEmailLogView extends WP_List_Table {
 			// if this PHP system support humanTime, than use it
 			if ( ! empty( $humanTime ) ) {
 				/* Translators: where %s indicates the relative time from now */
-				$date = sprintf( _x( '%s ago', 'A relative time as in "five days ago"', Postman::TEXT_DOMAIN ), $humanTime );
+				$date = sprintf( _x( '%s ago', 'A relative time as in "five days ago"', 'post-smtp' ), $humanTime );
 			}
 			$meta_values = get_post_meta( $post->ID );
 			$sent_to = array_map( 'sanitize_email', explode( ',' , $meta_values ['to_header'] [0] ) );
@@ -372,7 +372,7 @@ class PostmanEmailLogView extends WP_List_Table {
 					'sent_to' => implode( ', ', $sent_to ),
 					'title' => esc_html( $post->post_title ),
 					// the post status must be escaped as they are displayed in the HTML output
-					'status' => ($post->post_excerpt != null ? esc_html( $post->post_excerpt ) : __( 'Sent', Postman::TEXT_DOMAIN )),
+					'status' => ($post->post_excerpt != null ? esc_html( $post->post_excerpt ) : __( 'Sent', 'post-smtp' )),
 					'date' => date( "$date_format $time_format", strtotime( $post->post_date ) ),
 					'ID' => $post->ID,
 			);

--- a/Postman/Postman-Mail/PostmanDefaultModuleTransport.php
+++ b/Postman/Postman-Mail/PostmanDefaultModuleTransport.php
@@ -102,7 +102,7 @@ if (! class_exists ( 'PostmanSmtpModuleTransport' )) {
 			return self::SLUG;
 		}
 		public function getName() {
-			return __ ( 'Default', Postman::TEXT_DOMAIN );
+			return __ ( 'Default', 'post-smtp' );
 		}
 		public function getHostname() {
 			return 'localhost';

--- a/Postman/Postman-Mail/PostmanGmailApiModuleTransport.php
+++ b/Postman/Postman-Mail/PostmanGmailApiModuleTransport.php
@@ -98,7 +98,7 @@ class PostmanGmailApiModuleTransport extends PostmanAbstractZendModuleTransport 
 		return self::SLUG;
 	}
 	public function getName() {
-		return __ ( 'Gmail API', Postman::TEXT_DOMAIN );
+		return __ ( 'Gmail API', 'post-smtp' );
 	}
 	public function isEnvelopeFromValidationSupported() {
 		return false;
@@ -148,7 +148,7 @@ class PostmanGmailApiModuleTransport extends PostmanAbstractZendModuleTransport 
 	 */
 	public function getDeliveryDetails() {
 		/* translators: where (1) is the secure icon and (2) is the transport name */
-		return sprintf ( __ ( 'Postman will send mail via the <b>%1$s %2$s</b>.', Postman::TEXT_DOMAIN ), '🔐', $this->getName () );
+		return sprintf ( __ ( 'Postman will send mail via the <b>%1$s %2$s</b>.', 'post-smtp' ), '🔐', $this->getName () );
 	}
 	
 	/**
@@ -162,7 +162,7 @@ class PostmanGmailApiModuleTransport extends PostmanAbstractZendModuleTransport 
 			$this->setReadyForOAuthGrant ();
 			if ($this->isPermissionNeeded ()) {
 				/* translators: %1$s is the Client ID label, and %2$s is the Client Secret label */
-				$message = sprintf ( __ ( 'You have configured OAuth 2.0 authentication, but have not received permission to use it.', Postman::TEXT_DOMAIN ), $this->getScribe ()->getClientIdLabel (), $this->getScribe ()->getClientSecretLabel () );
+				$message = sprintf ( __ ( 'You have configured OAuth 2.0 authentication, but have not received permission to use it.', 'post-smtp' ), $this->getScribe ()->getClientIdLabel (), $this->getScribe ()->getClientSecretLabel () );
 				$message .= sprintf ( ' <a href="%s">%s</a>.', PostmanUtils::getGrantOAuthPermissionUrl (), $this->getScribe ()->getRequestPermissionLinkText () );
 				array_push ( $messages, $message );
 				$this->setNotConfiguredAndReady ();
@@ -217,7 +217,7 @@ class PostmanGmailApiModuleTransport extends PostmanAbstractZendModuleTransport 
 		$overrideItem ['auth_items'] = array (
 				array (
 						'selected' => true,
-						'name' => __ ( 'OAuth 2.0 (requires Client ID and Client Secret)', Postman::TEXT_DOMAIN ),
+						'name' => __ ( 'OAuth 2.0 (requires Client ID and Client Secret)', 'post-smtp' ),
 						'value' => 'oauth2' 
 				) 
 		);

--- a/Postman/Postman-Mail/PostmanMailgunTransport.php
+++ b/Postman/Postman-Mail/PostmanMailgunTransport.php
@@ -36,7 +36,7 @@ class PostmanMailgunTransport extends PostmanAbstractModuleTransport implements 
 		return self::SLUG;
 	}
 	public function getName() {
-		return __( 'Mailgun API', Postman::TEXT_DOMAIN );
+		return __( 'Mailgun API', 'post-smtp' );
 	}
 	/**
 	 * v0.2.1
@@ -78,7 +78,7 @@ class PostmanMailgunTransport extends PostmanAbstractModuleTransport implements 
 	}
 	public function getDeliveryDetails() {
 		/* translators: where (1) is the secure icon and (2) is the transport name */
-		return sprintf( __( 'Post SMTP will send mail via the <b>%1$s %2$s</b>.', Postman::TEXT_DOMAIN ), '🔐', $this->getName() );
+		return sprintf( __( 'Post SMTP will send mail via the <b>%1$s %2$s</b>.', 'post-smtp' ), '🔐', $this->getName() );
 	}
 
 	/**
@@ -102,17 +102,17 @@ class PostmanMailgunTransport extends PostmanAbstractModuleTransport implements 
 		$domainName = $this->options->getMailgunDomainName();
 
 		if ( empty( $apiKey ) ) {
-			array_push( $messages, __( 'API Key can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push( $messages, __( 'API Key can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady();
 		}
 
 		if ( empty( $domainName ) ) {
-			array_push( $messages, __( 'Domain Name can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push( $messages, __( 'Domain Name can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady();
 		}
 
 		if ( ! $this->isSenderConfigured() ) {
-			array_push( $messages, __( 'Message From Address can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push( $messages, __( 'Message From Address can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady();
 		}
 		return $messages;
@@ -155,7 +155,7 @@ class PostmanMailgunTransport extends PostmanAbstractModuleTransport implements 
 		$overrideItem ['auth_items'] = array(
 				array(
 						'selected' => true,
-						'name' => __( 'API Key', Postman::TEXT_DOMAIN ),
+						'name' => __( 'API Key', 'post-smtp' ),
 						'value' => 'api_key',
 				),
 		);
@@ -184,40 +184,40 @@ class PostmanMailgunTransport extends PostmanAbstractModuleTransport implements 
 	 */
 	public function addSettings() {
 		// the Mailgun Auth section
-		add_settings_section( PostmanMailgunTransport::MAILGUN_AUTH_SECTION, __( 'Authentication', Postman::TEXT_DOMAIN ), array(
+		add_settings_section( PostmanMailgunTransport::MAILGUN_AUTH_SECTION, __( 'Authentication', 'post-smtp' ), array(
 				$this,
 				'printMailgunAuthSectionInfo',
 		), PostmanMailgunTransport::MAILGUN_AUTH_OPTIONS );
 
-		add_settings_field( PostmanOptions::MAILGUN_API_KEY, __( 'API Key', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::MAILGUN_API_KEY, __( 'API Key', 'post-smtp' ), array(
 				$this,
 				'mailgun_api_key_callback',
 		), PostmanMailgunTransport::MAILGUN_AUTH_OPTIONS, PostmanMailgunTransport::MAILGUN_AUTH_SECTION );
 
-		add_settings_field( PostmanOptions::MAILGUN_DOMAIN_NAME, __( 'Domain Name', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::MAILGUN_DOMAIN_NAME, __( 'Domain Name', 'post-smtp' ), array(
 			$this,
 			'mailgun_domain_name_callback',
 		), PostmanMailgunTransport::MAILGUN_AUTH_OPTIONS, PostmanMailgunTransport::MAILGUN_AUTH_SECTION );
 
-		add_settings_field( PostmanOptions::MAILGUN_REGION, __( 'Mailgun Europe Region?', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::MAILGUN_REGION, __( 'Mailgun Europe Region?', 'post-smtp' ), array(
 			$this,
 			'mailgun_region_callback',
 		), PostmanMailgunTransport::MAILGUN_AUTH_OPTIONS, PostmanMailgunTransport::MAILGUN_AUTH_SECTION );
 	}
 	public function printMailgunAuthSectionInfo() {
 		/* Translators: Where (1) is the service URL and (2) is the service name and (3) is a api key URL */
-		printf( '<p id="wizard_mailgun_auth_help">%s</p>', sprintf( __( 'Create an account at <a href="%1$s" target="_blank">%2$s</a> and enter <a href="%3$s" target="_blank">an API key</a> below.', Postman::TEXT_DOMAIN ), 'https://mailgun.com', 'mailgun.com', 'https://app.mailgun.com/app/domains/' ) );
+		printf( '<p id="wizard_mailgun_auth_help">%s</p>', sprintf( __( 'Create an account at <a href="%1$s" target="_blank">%2$s</a> and enter <a href="%3$s" target="_blank">an API key</a> below.', 'post-smtp' ), 'https://mailgun.com', 'mailgun.com', 'https://app.mailgun.com/app/domains/' ) );
 	}
 
 	/**
 	 */
 	public function mailgun_api_key_callback() {
-		printf( '<input type="password" autocomplete="off" id="mailgun_api_key" name="postman_options[mailgun_api_key]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getMailgunApiKey() ? esc_attr( PostmanUtils::obfuscatePassword( $this->options->getMailgunApiKey() ) ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="password" autocomplete="off" id="mailgun_api_key" name="postman_options[mailgun_api_key]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getMailgunApiKey() ? esc_attr( PostmanUtils::obfuscatePassword( $this->options->getMailgunApiKey() ) ) : '', __( 'Required', 'post-smtp' ) );
 		print '<input type="button" id="toggleMailgunApiKey" value="Show Password" class="button button-secondary" style="visibility:hidden" />';
 	}
 
 	function mailgun_domain_name_callback() {
-		printf( '<input type="text" autocomplete="off" id="mailgun_domain_name" name="postman_options[mailgun_domain_name]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getMailgunDomainName() ? esc_attr( $this->options->getMailgunDomainName() ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="text" autocomplete="off" id="mailgun_domain_name" name="postman_options[mailgun_domain_name]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getMailgunDomainName() ? esc_attr( $this->options->getMailgunDomainName() ) : '', __( 'Required', 'post-smtp' ) );
 	}
 
 	function mailgun_region_callback() {
@@ -248,14 +248,14 @@ class PostmanMailgunTransport extends PostmanAbstractModuleTransport implements 
 	public function printWizardAuthenticationStep() {
 		print '<section class="wizard_mailgun">';
 		$this->printMailgunAuthSectionInfo();
-		printf( '<label for="api_key">%s</label>', __( 'API Key', Postman::TEXT_DOMAIN ) );
+		printf( '<label for="api_key">%s</label>', __( 'API Key', 'post-smtp' ) );
 		print '<br />';
 		print $this->mailgun_api_key_callback();
-		printf( '<label for="domain_name">%s</label>', __( 'Domain Name', Postman::TEXT_DOMAIN ) );
+		printf( '<label for="domain_name">%s</label>', __( 'Domain Name', 'post-smtp' ) );
 		print '<br />';
 		print $this->mailgun_domain_name_callback();
 		print '<br />';
-		printf( '<label for="mailgun_region">%s</label>', __( 'Mailgun Europe Region?', Postman::TEXT_DOMAIN ) );
+		printf( '<label for="mailgun_region">%s</label>', __( 'Mailgun Europe Region?', 'post-smtp' ) );
 		print '<br />';
 		print $this->mailgun_region_callback();
 		print '</section>';

--- a/Postman/Postman-Mail/PostmanMandrillTransport.php
+++ b/Postman/Postman-Mail/PostmanMandrillTransport.php
@@ -41,7 +41,7 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 		return self::SLUG;
 	}
 	public function getName() {
-		return __ ( 'Mandrill API', Postman::TEXT_DOMAIN );
+		return __ ( 'Mandrill API', 'post-smtp' );
 	}
 	/**
 	 * v0.2.1
@@ -132,7 +132,7 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 	 */
 	public function getDeliveryDetails() {
 		/* translators: where (1) is the secure icon and (2) is the transport name */
-		return sprintf ( __ ( 'Postman will send mail via the <b>%1$s %2$s</b>.', Postman::TEXT_DOMAIN ), '🔐', $this->getName () );
+		return sprintf ( __ ( 'Postman will send mail via the <b>%1$s %2$s</b>.', 'post-smtp' ), '🔐', $this->getName () );
 	}
 	
 	/**
@@ -144,11 +144,11 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 		$messages = parent::validateTransportConfiguration ();
 		$apiKey = $this->options->getMandrillApiKey ();
 		if (empty ( $apiKey )) {
-			array_push ( $messages, __ ( 'API Key can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push ( $messages, __ ( 'API Key can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady ();
 		}
 		if (! $this->isSenderConfigured ()) {
-			array_push ( $messages, __ ( 'Message From Address can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push ( $messages, __ ( 'Message From Address can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady ();
 		}
 		return $messages;
@@ -191,7 +191,7 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 		$overrideItem ['auth_items'] = array (
 				array (
 						'selected' => true,
-						'name' => __ ( 'API Key', Postman::TEXT_DOMAIN ),
+						'name' => __ ( 'API Key', 'post-smtp' ),
 						'value' => 'api_key' 
 				) 
 		);
@@ -220,12 +220,12 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 	 */
 	public function addSettings() {
 		// the Mandrill Auth section
-		add_settings_section ( PostmanMandrillTransport::MANDRILL_AUTH_SECTION, __ ( 'Authentication', Postman::TEXT_DOMAIN ), array (
+		add_settings_section ( PostmanMandrillTransport::MANDRILL_AUTH_SECTION, __ ( 'Authentication', 'post-smtp' ), array (
 				$this,
 				'printMandrillAuthSectionInfo' 
 		), PostmanMandrillTransport::MANDRILL_AUTH_OPTIONS );
 		
-		add_settings_field ( PostmanOptions::MANDRILL_API_KEY, __ ( 'API Key', Postman::TEXT_DOMAIN ), array (
+		add_settings_field ( PostmanOptions::MANDRILL_API_KEY, __ ( 'API Key', 'post-smtp' ), array (
 				$this,
 				'mandrill_api_key_callback' 
 		), PostmanMandrillTransport::MANDRILL_AUTH_OPTIONS, PostmanMandrillTransport::MANDRILL_AUTH_SECTION );
@@ -235,13 +235,13 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 	 */
 	public function printMandrillAuthSectionInfo() {
 		/* Translators: Where (1) is the service URL and (2) is the service name and (3) is a api key URL */
-		printf ( '<p id="wizard_mandrill_auth_help">%s</p>', sprintf ( __ ( 'Create an account at <a href="%1$s" target="_blank">%2$s</a> and enter <a href="%3$s" target="_blank">an API key</a> below.', Postman::TEXT_DOMAIN ), 'https://mandrillapp.com', 'Mandrillapp.com', 'https://mandrillapp.com/settings' ) );
+		printf ( '<p id="wizard_mandrill_auth_help">%s</p>', sprintf ( __ ( 'Create an account at <a href="%1$s" target="_blank">%2$s</a> and enter <a href="%3$s" target="_blank">an API key</a> below.', 'post-smtp' ), 'https://mandrillapp.com', 'Mandrillapp.com', 'https://mandrillapp.com/settings' ) );
 	}
 	
 	/**
 	 */
 	public function mandrill_api_key_callback() {
-		printf ( '<input type="password" autocomplete="off" id="mandrill_api_key" name="postman_options[mandrill_api_key]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getMandrillApiKey () ? esc_attr ( PostmanUtils::obfuscatePassword ( $this->options->getMandrillApiKey () ) ) : '', __ ( 'Required', Postman::TEXT_DOMAIN ) );
+		printf ( '<input type="password" autocomplete="off" id="mandrill_api_key" name="postman_options[mandrill_api_key]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getMandrillApiKey () ? esc_attr ( PostmanUtils::obfuscatePassword ( $this->options->getMandrillApiKey () ) ) : '', __ ( 'Required', 'post-smtp' ) );
 		print ' <input type="button" id="toggleMandrillApiKey" value="Show Password" class="button button-secondary" style="visibility:hidden" />';
 	}
 	
@@ -268,7 +268,7 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 	public function printWizardAuthenticationStep() {
 		print '<section class="wizard_mandrill">';
 		$this->printMandrillAuthSectionInfo ();
-		printf ( '<label for="api_key">%s</label>', __ ( 'API Key', Postman::TEXT_DOMAIN ) );
+		printf ( '<label for="api_key">%s</label>', __ ( 'API Key', 'post-smtp' ) );
 		print '<br />';
 		print $this->mandrill_api_key_callback ();
 		print '</section>';

--- a/Postman/Postman-Mail/PostmanMessage.php
+++ b/Postman/Postman-Mail/PostmanMessage.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'PostmanMessage' ) ) {
 		}
 
 		function __get( $name ) {
-			$message = __( '<code>%1$s</code> property of a <code>PostmanMessage</code> object is <strong>not supported</strong>. For now all of this class properties are private.', Postman::TEXT_DOMAIN );
+			$message = __( '<code>%1$s</code> property of a <code>PostmanMessage</code> object is <strong>not supported</strong>. For now all of this class properties are private.', 'post-smtp' );
 
 			if ( WP_DEBUG ) {
 				trigger_error( sprintf( $message, $name ) );
@@ -63,7 +63,7 @@ if ( ! class_exists( 'PostmanMessage' ) ) {
 			$class = new ReflectionClass(__CLASS__);
 			$methods = $class->getMethods(ReflectionMethod::IS_PUBLIC );
 
-			$message = __( '<code>%1$s</code> method of a <code>PostmanMessage</code> object is <strong>not supported</strong>. Use one of the following methods <pre><code>%2$s</code></pre>', Postman::TEXT_DOMAIN );
+			$message = __( '<code>%1$s</code> method of a <code>PostmanMessage</code> object is <strong>not supported</strong>. Use one of the following methods <pre><code>%2$s</code></pre>', 'post-smtp' );
 
 			if ( WP_DEBUG ) {
 				trigger_error( sprintf( $message, $name, print_r( $methods, true ) ) );

--- a/Postman/Postman-Mail/PostmanModuleTransport.php
+++ b/Postman/Postman-Mail/PostmanModuleTransport.php
@@ -503,7 +503,7 @@ abstract class PostmanAbstractZendModuleTransport extends PostmanAbstractModuleT
 		$deliveryDetails ['host'] = $this->getHostname () . ':' . $this->getPort ();
 		$deliveryDetails ['auth_desc'] = $this->getAuthenticationDescription ( $this->getAuthenticationType () );
 		/* translators: where (1) is the transport type, (2) is the host, and (3) is the Authentication Type (e.g. Postman will send mail via smtp.gmail.com:465 using OAuth 2.0 authentication.) */
-		return sprintf ( __ ( 'Postman will send mail via %1$s to %2$s using %3$s authentication.', Postman::TEXT_DOMAIN ), '<b>' . $deliveryDetails ['transport_name'] . '</b>', '<b>' . $deliveryDetails ['host'] . '</b>', '<b>' . $deliveryDetails ['auth_desc'] . '</b>' );
+		return sprintf ( __ ( 'Postman will send mail via %1$s to %2$s using %3$s authentication.', 'post-smtp' ), '<b>' . $deliveryDetails ['transport_name'] . '</b>', '<b>' . $deliveryDetails ['host'] . '</b>', '<b>' . $deliveryDetails ['auth_desc'] . '</b>' );
 	}
 	
 	/**
@@ -531,7 +531,7 @@ abstract class PostmanAbstractZendModuleTransport extends PostmanAbstractModuleT
 		if (PostmanOptions::AUTHENTICATION_TYPE_OAUTH2 == $authType) {
 			return 'OAuth 2.0';
 		} else if (PostmanOptions::AUTHENTICATION_TYPE_NONE == $authType) {
-			return _x ( 'no', 'as in "There is no Spoon"', Postman::TEXT_DOMAIN );
+			return _x ( 'no', 'as in "There is no Spoon"', 'post-smtp' );
 		} else {
 			switch ($authType) {
 				case PostmanOptions::AUTHENTICATION_TYPE_CRAMMD5 :
@@ -550,7 +550,7 @@ abstract class PostmanAbstractZendModuleTransport extends PostmanAbstractModuleT
 					$authDescription = $authType;
 					break;
 			}
-			return sprintf ( '%s (%s)', __ ( 'Password', Postman::TEXT_DOMAIN ), $authDescription );
+			return sprintf ( '%s (%s)', __ ( 'Password', 'post-smtp' ), $authDescription );
 		}
 	}
 	
@@ -575,13 +575,13 @@ abstract class PostmanAbstractZendModuleTransport extends PostmanAbstractModuleT
 		parent::validateTransportConfiguration ();
 		$messages = parent::validateTransportConfiguration ();
 		if (! $this->isSenderConfigured ()) {
-			array_push ( $messages, __ ( 'Message From Address can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push ( $messages, __ ( 'Message From Address can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady ();
 		}
 		if ($this->getAuthenticationType () == PostmanOptions::AUTHENTICATION_TYPE_OAUTH2) {
 			if (! $this->isOAuth2ClientIdAndClientSecretConfigured ()) {
 				/* translators: %1$s is the Client ID label, and %2$s is the Client Secret label (e.g. Warning: OAuth 2.0 authentication requires an OAuth 2.0-capable Outgoing Mail Server, Sender Email Address, Client ID, and Client Secret.) */
-				array_push ( $messages, sprintf ( __ ( 'OAuth 2.0 authentication requires a %1$s and %2$s.', Postman::TEXT_DOMAIN ), $this->getScribe ()->getClientIdLabel (), $this->getScribe ()->getClientSecretLabel () ) );
+				array_push ( $messages, sprintf ( __ ( 'OAuth 2.0 authentication requires a %1$s and %2$s.', 'post-smtp' ), $this->getScribe ()->getClientIdLabel (), $this->getScribe ()->getClientSecretLabel () ) );
 				$this->setNotConfiguredAndReady ();
 			}
 		}
@@ -703,21 +703,21 @@ abstract class PostmanAbstractZendModuleTransport extends PostmanAbstractModuleT
 			if ($socket->auth_crammd5 || $socket->auth_login || $socket->authPlain) {
 				array_push ( $overrideAuthItems, array (
 						'selected' => $passwordMode,
-						'name' => __ ( 'Password (requires username and password)', Postman::TEXT_DOMAIN ),
+						'name' => __ ( 'Password (requires username and password)', 'post-smtp' ),
 						'value' => 'password' 
 				) );
 			}
 			if ($socket->auth_xoauth || $winningRecommendation ['auth'] == 'oauth2') {
 				array_push ( $overrideAuthItems, array (
 						'selected' => $oauth2Mode,
-						'name' => __ ( 'OAuth 2.0 (requires Client ID and Client Secret)', Postman::TEXT_DOMAIN ),
+						'name' => __ ( 'OAuth 2.0 (requires Client ID and Client Secret)', 'post-smtp' ),
 						'value' => 'oauth2' 
 				) );
 			}
 			if ($socket->auth_none) {
 				array_push ( $overrideAuthItems, array (
 						'selected' => $noAuthMode,
-						'name' => __ ( 'None', Postman::TEXT_DOMAIN ),
+						'name' => __ ( 'None', 'post-smtp' ),
 						'value' => 'none' 
 				) );
 			}

--- a/Postman/Postman-Mail/PostmanMyMailConnector.php
+++ b/Postman/Postman-Mail/PostmanMyMailConnector.php
@@ -172,7 +172,7 @@ if ( ! class_exists( 'PostmanMyMailConnector' ) ) {
 		 * @return void
 		 */
 		public function delivery_method( $delivery_methods ) {
-			$delivery_methods [ MAILSTER_POSTMAN_ID ] = __( 'Postman SMTP', Postman::TEXT_DOMAIN );
+			$delivery_methods [ MAILSTER_POSTMAN_ID ] = __( 'Postman SMTP', 'post-smtp' );
 			return $delivery_methods;
 		}
 
@@ -196,7 +196,7 @@ if ( ! class_exists( 'PostmanMyMailConnector' ) ) {
 		 */
 		public function activate() {
 			if ( defined( 'MAILSTER_VERSION' ) && version_compare( MAILSTER_POSTMAN_REQUIRED_VERSION, MAILSTER_VERSION, '<=' ) ) {
-				mailster_notice( sprintf( __( 'MyMail: Change the delivery method in the %s!', Postman::TEXT_DOMAIN ), sprintf( '<a href="edit.php?post_type=newsletter&page=mailster_settings&mailster_remove_notice=mailster_delivery_method#delivery">%s</a>', __( 'Settings', 'postman-smtp' ) ) ), '', false, 'delivery_method' );
+				mailster_notice( sprintf( __( 'MyMail: Change the delivery method in the %s!', 'post-smtp' ), sprintf( '<a href="edit.php?post_type=newsletter&page=mailster_settings&mailster_remove_notice=mailster_delivery_method#delivery">%s</a>', __( 'Settings', 'postman-smtp' ) ) ), '', false, 'delivery_method' );
 				$this->reset();
 			}
 		}
@@ -212,7 +212,7 @@ if ( ! class_exists( 'PostmanMyMailConnector' ) ) {
 				if ( mailster_option( 'deliverymethod' ) == MAILSTER_POSTMAN_ID ) {
 					mailster_update_option( 'deliverymethod', 'simple' );
 					/* Translators where %s is the name of the page */
-					mailster_notice( sprintf( __( 'MyMail: Change the delivery method in the %s!', Postman::TEXT_DOMAIN ), sprintf( '<a href="edit.php?post_type=newsletter&page=mailster_settings&mailster_remove_notice=mailster_delivery_method#delivery">%s</a>', __( 'Settings', 'postman-smtp' ) ) ), '', false, 'delivery_method' );
+					mailster_notice( sprintf( __( 'MyMail: Change the delivery method in the %s!', 'post-smtp' ), sprintf( '<a href="edit.php?post_type=newsletter&page=mailster_settings&mailster_remove_notice=mailster_delivery_method#delivery">%s</a>', __( 'Settings', 'postman-smtp' ) ) ), '', false, 'delivery_method' );
 				}
 			}
 		}

--- a/Postman/Postman-Mail/PostmanSendGridMailEngine.php
+++ b/Postman/Postman-Mail/PostmanSendGridMailEngine.php
@@ -219,22 +219,22 @@ if ( ! class_exists( 'PostmanSendGridMailEngine' ) ) {
 		private function errorCodesMap($error_code) {
 			switch ($error_code) {
 				case 413:
-					$message = sprintf( __( 'ERROR: The JSON payload you have included in your request is too large. Status code is %1$s', Postman::TEXT_DOMAIN ), $error_code );
+					$message = sprintf( __( 'ERROR: The JSON payload you have included in your request is too large. Status code is %1$s', 'post-smtp' ), $error_code );
 					break;
 				case 429:
-					$message = sprintf( __( 'ERROR: The number of requests you have made exceeds SendGrid rate limitations. Status code is %1$s', Postman::TEXT_DOMAIN ), $error_code );
+					$message = sprintf( __( 'ERROR: The number of requests you have made exceeds SendGrid rate limitations. Status code is %1$s', 'post-smtp' ), $error_code );
 					break;
 				case 500:
-					$message = sprintf( __( 'ERROR: An error occurred on a SendGrid server. Status code is %1$s', Postman::TEXT_DOMAIN ), $error_code );
+					$message = sprintf( __( 'ERROR: An error occurred on a SendGrid server. Status code is %1$s', 'post-smtp' ), $error_code );
 					break;
 				case 513:
-					$message = sprintf( __( 'ERROR: The SendGrid v3 Web API is not available. Status code is %1$s', Postman::TEXT_DOMAIN ), $error_code );
+					$message = sprintf( __( 'ERROR: The SendGrid v3 Web API is not available. Status code is %1$s', 'post-smtp' ), $error_code );
 					break;
 				case 502:
-					$message =  sprintf( __( 'ERROR: No recipient supplied. Status code is %1$s', Postman::TEXT_DOMAIN ), $error_code );
+					$message =  sprintf( __( 'ERROR: No recipient supplied. Status code is %1$s', 'post-smtp' ), $error_code );
 					break;
 				default:
-					$message = sprintf( __( 'ERROR: Status code is %1$s', Postman::TEXT_DOMAIN ), $error_code );
+					$message = sprintf( __( 'ERROR: Status code is %1$s', 'post-smtp' ), $error_code );
 			}
 
 			return $message;

--- a/Postman/Postman-Mail/PostmanSendGridTransport.php
+++ b/Postman/Postman-Mail/PostmanSendGridTransport.php
@@ -36,7 +36,7 @@ class PostmanSendGridTransport extends PostmanAbstractModuleTransport implements
 		return self::SLUG;
 	}
 	public function getName() {
-		return __ ( 'SendGrid API', Postman::TEXT_DOMAIN );
+		return __ ( 'SendGrid API', 'post-smtp' );
 	}
 	/**
 	 * v0.2.1
@@ -76,7 +76,7 @@ class PostmanSendGridTransport extends PostmanAbstractModuleTransport implements
 	}
 	public function getDeliveryDetails() {
 		/* translators: where (1) is the secure icon and (2) is the transport name */
-		return sprintf ( __ ( 'Postman will send mail via the <b>%1$s %2$s</b>.', Postman::TEXT_DOMAIN ), '🔐', $this->getName () );
+		return sprintf ( __ ( 'Postman will send mail via the <b>%1$s %2$s</b>.', 'post-smtp' ), '🔐', $this->getName () );
 	}
 	
 	/**
@@ -98,11 +98,11 @@ class PostmanSendGridTransport extends PostmanAbstractModuleTransport implements
 		$messages = parent::validateTransportConfiguration ();
 		$apiKey = $this->options->getSendGridApiKey ();
 		if (empty ( $apiKey )) {
-			array_push ( $messages, __ ( 'API Key can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push ( $messages, __ ( 'API Key can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady ();
 		}
 		if (! $this->isSenderConfigured ()) {
-			array_push ( $messages, __ ( 'Message From Address can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push ( $messages, __ ( 'Message From Address can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady ();
 		}
 		return $messages;
@@ -145,7 +145,7 @@ class PostmanSendGridTransport extends PostmanAbstractModuleTransport implements
 		$overrideItem ['auth_items'] = array (
 				array (
 						'selected' => true,
-						'name' => __ ( 'API Key', Postman::TEXT_DOMAIN ),
+						'name' => __ ( 'API Key', 'post-smtp' ),
 						'value' => 'api_key' 
 				) 
 		);
@@ -174,25 +174,25 @@ class PostmanSendGridTransport extends PostmanAbstractModuleTransport implements
 	 */
 	public function addSettings() {
 		// the SendGrid Auth section
-		add_settings_section ( PostmanSendGridTransport::SENDGRID_AUTH_SECTION, __ ( 'Authentication', Postman::TEXT_DOMAIN ), array (
+		add_settings_section ( PostmanSendGridTransport::SENDGRID_AUTH_SECTION, __ ( 'Authentication', 'post-smtp' ), array (
 				$this,
 				'printSendGridAuthSectionInfo' 
 		), PostmanSendGridTransport::SENDGRID_AUTH_OPTIONS );
 		
-		add_settings_field ( PostmanOptions::SENDGRID_API_KEY, __ ( 'API Key', Postman::TEXT_DOMAIN ), array (
+		add_settings_field ( PostmanOptions::SENDGRID_API_KEY, __ ( 'API Key', 'post-smtp' ), array (
 				$this,
 				'sendgrid_api_key_callback' 
 		), PostmanSendGridTransport::SENDGRID_AUTH_OPTIONS, PostmanSendGridTransport::SENDGRID_AUTH_SECTION );
 	}
 	public function printSendGridAuthSectionInfo() {
 		/* Translators: Where (1) is the service URL and (2) is the service name and (3) is a api key URL */
-		printf ( '<p id="wizard_sendgrid_auth_help">%s</p>', sprintf ( __ ( 'Create an account at <a href="%1$s" target="_blank">%2$s</a> and enter <a href="%3$s" target="_blank">an API key</a> below.', Postman::TEXT_DOMAIN ), 'https://sendgrid.com', 'SendGrid.com', 'https://app.sendgrid.com/settings/api_keys' ) );
+		printf ( '<p id="wizard_sendgrid_auth_help">%s</p>', sprintf ( __ ( 'Create an account at <a href="%1$s" target="_blank">%2$s</a> and enter <a href="%3$s" target="_blank">an API key</a> below.', 'post-smtp' ), 'https://sendgrid.com', 'SendGrid.com', 'https://app.sendgrid.com/settings/api_keys' ) );
 	}
 	
 	/**
 	 */
 	public function sendgrid_api_key_callback() {
-		printf ( '<input type="password" autocomplete="off" id="sendgrid_api_key" name="postman_options[sendgrid_api_key]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getSendGridApiKey () ? esc_attr ( PostmanUtils::obfuscatePassword ( $this->options->getSendGridApiKey () ) ) : '', __ ( 'Required', Postman::TEXT_DOMAIN ) );
+		printf ( '<input type="password" autocomplete="off" id="sendgrid_api_key" name="postman_options[sendgrid_api_key]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getSendGridApiKey () ? esc_attr ( PostmanUtils::obfuscatePassword ( $this->options->getSendGridApiKey () ) ) : '', __ ( 'Required', 'post-smtp' ) );
 		print ' <input type="button" id="toggleSendGridApiKey" value="Show Password" class="button button-secondary" style="visibility:hidden" />';
 	}
 	
@@ -219,7 +219,7 @@ class PostmanSendGridTransport extends PostmanAbstractModuleTransport implements
 	public function printWizardAuthenticationStep() {
 		print '<section class="wizard_sendgrid">';
 		$this->printSendGridAuthSectionInfo ();
-		printf ( '<label for="api_key">%s</label>', __ ( 'API Key', Postman::TEXT_DOMAIN ) );
+		printf ( '<label for="api_key">%s</label>', __ ( 'API Key', 'post-smtp' ) );
 		print '<br />';
 		print $this->sendgrid_api_key_callback ();
 		print '</section>';

--- a/Postman/Postman-Mail/PostmanSmtpModuleTransport.php
+++ b/Postman/Postman-Mail/PostmanSmtpModuleTransport.php
@@ -91,21 +91,21 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	protected function validateTransportConfiguration() {
 		$messages = parent::validateTransportConfiguration();
 		if ( ! $this->isHostConfigured( $this->options ) ) {
-			array_push( $messages, __( 'Outgoing Mail Server Hostname and Port can not be empty.', Postman::TEXT_DOMAIN ) );
+			array_push( $messages, __( 'Outgoing Mail Server Hostname and Port can not be empty.', 'post-smtp' ) );
 			$this->setNotConfiguredAndReady();
 		}
 		if ( ! $this->isEnvelopeFromConfigured() ) {
-			array_push( $messages, __( 'Envelope-From Email Address can not be empty', Postman::TEXT_DOMAIN ) . '.' );
+			array_push( $messages, __( 'Envelope-From Email Address can not be empty', 'post-smtp' ) . '.' );
 			$this->setNotConfiguredAndReady();
 		}
 		if ( $this->options->isAuthTypePassword() && ! $this->isPasswordAuthenticationConfigured( $this->options ) ) {
-			array_push( $messages, __( 'Username and password can not be empty.', Postman::TEXT_DOMAIN ) );
+			array_push( $messages, __( 'Username and password can not be empty.', 'post-smtp' ) );
 			$this->setNotConfiguredAndReady();
 		}
 		if ( $this->getAuthenticationType() == PostmanOptions::AUTHENTICATION_TYPE_OAUTH2 ) {
 			if ( ! $this->isOAuth2SupportedHostConfigured() ) {
 				/* translators: %1$s is the Client ID label, and %2$s is the Client Secret label (e.g. Warning: OAuth 2.0 authentication requires an OAuth 2.0-capable Outgoing Mail Server, Sender Email Address, Client ID, and Client Secret.) */
-				array_push( $messages, sprintf( __( 'OAuth 2.0 authentication requires a supported OAuth 2.0-capable Outgoing Mail Server.', Postman::TEXT_DOMAIN ) ) );
+				array_push( $messages, sprintf( __( 'OAuth 2.0 authentication requires a supported OAuth 2.0-capable Outgoing Mail Server.', 'post-smtp' ) ) );
 				$this->setNotConfiguredAndReady();
 			}
 		}
@@ -113,7 +113,7 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 			$this->setReadyForOAuthGrant();
 			if ( $this->isPermissionNeeded( $this->options, $this->getOAuthToken() ) ) {
 				/* translators: %1$s is the Client ID label, and %2$s is the Client Secret label */
-				$message = sprintf( __( 'You have configured OAuth 2.0 authentication, but have not received permission to use it.', Postman::TEXT_DOMAIN ), $this->getScribe()->getClientIdLabel(), $this->getScribe()->getClientSecretLabel() );
+				$message = sprintf( __( 'You have configured OAuth 2.0 authentication, but have not received permission to use it.', 'post-smtp' ), $this->getScribe()->getClientIdLabel(), $this->getScribe()->getClientSecretLabel() );
 				$message .= sprintf( ' <a href="%s">%s</a>.', PostmanUtils::getGrantOAuthPermissionUrl(), $this->getScribe()->getRequestPermissionLinkText() );
 				array_push( $messages, $message );
 				$this->setNotConfiguredAndReady();
@@ -265,7 +265,7 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 			$authDesc = $this->getAuthenticationDescription( $recommendation ['auth'] );
 			$recommendation ['label'] = sprintf( 'SMTP - %2$s:%3$d', $transportDescription, $hostData->hostnameDomainOnly, $port );
 			/* translators: where %1$s is a description of the transport (eg. SMTPS-SSL), %2$s is a description of the authentication (eg. Password-CRAMMD5), %3$d is the TCP port (eg. 465), %4$d is the hostname */
-			$recommendation ['message'] = sprintf( __( 'Postman recommends %1$s with %2$s authentication to host %4$s on port %3$d.', Postman::TEXT_DOMAIN ), $transportDescription, $authDesc, $port, $hostname );
+			$recommendation ['message'] = sprintf( __( 'Postman recommends %1$s with %2$s authentication to host %4$s on port %3$d.', 'post-smtp' ), $transportDescription, $authDesc, $port, $hostname );
 		}
 
 		// fill-in the rest of the recommendation
@@ -322,53 +322,53 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 		$oauthScribe = $transport->getScribe();
 
 		// Sanitize
-		add_settings_section( PostmanAdminController::SMTP_SECTION, __( 'Transport Settings', Postman::TEXT_DOMAIN ), array(
+		add_settings_section( PostmanAdminController::SMTP_SECTION, __( 'Transport Settings', 'post-smtp' ), array(
 				$this,
 				'printSmtpSectionInfo',
 		), PostmanAdminController::SMTP_OPTIONS );
 
-		add_settings_field( PostmanOptions::HOSTNAME, __( 'Outgoing Mail Server Hostname', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::HOSTNAME, __( 'Outgoing Mail Server Hostname', 'post-smtp' ), array(
 				$this,
 				'hostname_callback',
 		), PostmanAdminController::SMTP_OPTIONS, PostmanAdminController::SMTP_SECTION );
 
-		add_settings_field( PostmanOptions::PORT, __( 'Outgoing Mail Server Port', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::PORT, __( 'Outgoing Mail Server Port', 'post-smtp' ), array(
 				$this,
 				'port_callback',
 		), PostmanAdminController::SMTP_OPTIONS, PostmanAdminController::SMTP_SECTION );
 
-		add_settings_field( PostmanOptions::ENVELOPE_SENDER, __( 'Envelope-From Email Address', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::ENVELOPE_SENDER, __( 'Envelope-From Email Address', 'post-smtp' ), array(
 				$this,
 				'sender_email_callback',
 		), PostmanAdminController::SMTP_OPTIONS, PostmanAdminController::SMTP_SECTION );
 
-		add_settings_field( PostmanOptions::SECURITY_TYPE, _x( 'Security', 'Configuration Input Field', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::SECURITY_TYPE, _x( 'Security', 'Configuration Input Field', 'post-smtp' ), array(
 				$this,
 				'encryption_type_callback',
 		), PostmanAdminController::SMTP_OPTIONS, PostmanAdminController::SMTP_SECTION );
 
-		add_settings_field( PostmanOptions::AUTHENTICATION_TYPE, __( 'Authentication', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::AUTHENTICATION_TYPE, __( 'Authentication', 'post-smtp' ), array(
 				$this,
 				'authentication_type_callback',
 		), PostmanAdminController::SMTP_OPTIONS, PostmanAdminController::SMTP_SECTION );
 
-		add_settings_section( PostmanAdminController::BASIC_AUTH_SECTION, __( 'Authentication', Postman::TEXT_DOMAIN ), array(
+		add_settings_section( PostmanAdminController::BASIC_AUTH_SECTION, __( 'Authentication', 'post-smtp' ), array(
 				$this,
 				'printBasicAuthSectionInfo',
 		), PostmanAdminController::BASIC_AUTH_OPTIONS );
 
-		add_settings_field( PostmanOptions::BASIC_AUTH_USERNAME, __( 'Username', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::BASIC_AUTH_USERNAME, __( 'Username', 'post-smtp' ), array(
 				$this,
 				'basic_auth_username_callback',
 		), PostmanAdminController::BASIC_AUTH_OPTIONS, PostmanAdminController::BASIC_AUTH_SECTION );
 
-		add_settings_field( PostmanOptions::BASIC_AUTH_PASSWORD, __( 'Password', Postman::TEXT_DOMAIN ), array(
+		add_settings_field( PostmanOptions::BASIC_AUTH_PASSWORD, __( 'Password', 'post-smtp' ), array(
 				$this,
 				'basic_auth_password_callback',
 		), PostmanAdminController::BASIC_AUTH_OPTIONS, PostmanAdminController::BASIC_AUTH_SECTION );
 
 		// the OAuth section
-		add_settings_section( PostmanAdminController::OAUTH_SECTION, __( 'Authentication', Postman::TEXT_DOMAIN ), array(
+		add_settings_section( PostmanAdminController::OAUTH_SECTION, __( 'Authentication', 'post-smtp' ), array(
 				$this,
 				'printOAuthSectionInfo',
 		), PostmanAdminController::OAUTH_AUTH_OPTIONS );
@@ -398,21 +398,21 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	 * Print the Section text
 	 */
 	public function printSmtpSectionInfo() {
-		print __( 'Configure the communication with the mail server.', Postman::TEXT_DOMAIN );
+		print __( 'Configure the communication with the mail server.', 'post-smtp' );
 	}
 
 	/**
 	 * Get the settings option array and print one of its values
 	 */
 	public function hostname_callback() {
-		printf( '<input type="text" id="input_hostname" name="postman_options[hostname]" value="%s" size="40" class="required" placeholder="%s"/>', null !== $this->options->getHostname() ? esc_attr( $this->options->getHostname() ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="text" id="input_hostname" name="postman_options[hostname]" value="%s" size="40" class="required" placeholder="%s"/>', null !== $this->options->getHostname() ? esc_attr( $this->options->getHostname() ) : '', __( 'Required', 'post-smtp' ) );
 	}
 
 	/**
 	 * Get the settings option array and print one of its values
 	 */
 	public function port_callback( $args ) {
-		printf( '<input type="text" id="input_port" name="postman_options[port]" value="%s" %s placeholder="%s"/>', null !== $this->options->getPort() ? esc_attr( $this->options->getPort() ) : '', isset( $args ['style'] ) ? $args ['style'] : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="text" id="input_port" name="postman_options[port]" value="%s" %s placeholder="%s"/>', null !== $this->options->getPort() ? esc_attr( $this->options->getPort() ) : '', isset( $args ['style'] ) ? $args ['style'] : '', __( 'Required', 'post-smtp' ) );
 	}
 
 	/**
@@ -421,7 +421,7 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	public function encryption_type_callback() {
 		$encType = $this->options->getEncryptionType();
 		print '<select id="input_enc_type" class="input_encryption_type" name="postman_options[enc_type]">';
-		printf( '<option class="input_enc_type_none" value="%s" %s>%s</option>', PostmanOptions::SECURITY_TYPE_NONE, $encType == PostmanOptions::SECURITY_TYPE_NONE ? 'selected="selected"' : '', __( 'None', Postman::TEXT_DOMAIN ) );
+		printf( '<option class="input_enc_type_none" value="%s" %s>%s</option>', PostmanOptions::SECURITY_TYPE_NONE, $encType == PostmanOptions::SECURITY_TYPE_NONE ? 'selected="selected"' : '', __( 'None', 'post-smtp' ) );
 		printf( '<option class="input_enc_type_ssl" value="%s" %s>%s</option>', PostmanOptions::SECURITY_TYPE_SMTPS, $encType == PostmanOptions::SECURITY_TYPE_SMTPS ? 'selected="selected"' : '', 'SMTPS' );
 		printf( '<option class="input_enc_type_tls" value="%s" %s>%s</option>', PostmanOptions::SECURITY_TYPE_STARTTLS, $encType == PostmanOptions::SECURITY_TYPE_STARTTLS ? 'selected="selected"' : '', 'STARTTLS' );
 		print '</select>';
@@ -445,7 +445,7 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	 * Print the Section text
 	 */
 	public function printBasicAuthSectionInfo() {
-		print __( 'Enter the account credentials.', Postman::TEXT_DOMAIN );
+		print __( 'Enter the account credentials.', 'post-smtp' );
 	}
 
 	/**
@@ -453,9 +453,9 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	 */
 	public function basic_auth_username_callback() {
 		$inputValue = (null !== $this->options->getUsername() ? esc_attr( $this->options->getUsername() ) : '');
-		$inputDescription = __( 'The Username is usually the same as the Envelope-From Email Address.', Postman::TEXT_DOMAIN );
+		$inputDescription = __( 'The Username is usually the same as the Envelope-From Email Address.', 'post-smtp' );
 		print ('<input tabindex="99" id="fake_user_name" name="fake_user[name]" style="position:absolute; top:-500px;" type="text" value="Safari Autofill Me">') ;
-		printf( '<input type="text" id="input_basic_auth_username" name="postman_options[basic_auth_username]" value="%s" size="40" class="required" placeholder="%s"/><br/><span class="postman_input_description">%s</span>', $inputValue, __( 'Required', Postman::TEXT_DOMAIN ), $inputDescription );
+		printf( '<input type="text" id="input_basic_auth_username" name="postman_options[basic_auth_username]" value="%s" size="40" class="required" placeholder="%s"/><br/><span class="postman_input_description">%s</span>', $inputValue, __( 'Required', 'post-smtp' ), $inputDescription );
 	}
 
 	/**
@@ -463,7 +463,7 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	 */
 	public function basic_auth_password_callback() {
 		print ('<input tabindex="99" id="fake_password" name="fake[password]" style="position:absolute; top:-500px;" type="password" value="Safari Autofill Me">') ;
-		printf( '<input type="password" id="input_basic_auth_password" name="postman_options[basic_auth_password]" value="%s" size="40" class="required" placeholder="%s"/>', null !== $this->options->getPassword() ? esc_attr( PostmanUtils::obfuscatePassword( $this->options->getPassword() ) ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="password" id="input_basic_auth_password" name="postman_options[basic_auth_password]" value="%s" size="40" class="required" placeholder="%s"/>', null !== $this->options->getPassword() ? esc_attr( PostmanUtils::obfuscatePassword( $this->options->getPassword() ) ) : '', __( 'Required', 'post-smtp' ) );
 		print ' <input type="button" id="togglePasswordField" value="Show Password" class="button button-secondary" style="visibility:hidden" />';
 	}
 
@@ -471,14 +471,14 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	 * Get the settings option array and print one of its values
 	 */
 	public function oauth_client_id_callback() {
-		printf( '<input type="text" onClick="this.setSelectionRange(0, this.value.length)" id="oauth_client_id" name="postman_options[oauth_client_id]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getClientId() ? esc_attr( $this->options->getClientId() ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="text" onClick="this.setSelectionRange(0, this.value.length)" id="oauth_client_id" name="postman_options[oauth_client_id]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getClientId() ? esc_attr( $this->options->getClientId() ) : '', __( 'Required', 'post-smtp' ) );
 	}
 
 	/**
 	 * Get the settings option array and print one of its values
 	 */
 	public function oauth_client_secret_callback() {
-		printf( '<input type="text" onClick="this.setSelectionRange(0, this.value.length)" autocomplete="off" id="oauth_client_secret" name="postman_options[oauth_client_secret]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getClientSecret() ? esc_attr( $this->options->getClientSecret() ) : '', __( 'Required', Postman::TEXT_DOMAIN ) );
+		printf( '<input type="text" onClick="this.setSelectionRange(0, this.value.length)" autocomplete="off" id="oauth_client_secret" name="postman_options[oauth_client_secret]" value="%s" size="60" class="required" placeholder="%s"/>', null !== $this->options->getClientSecret() ? esc_attr( $this->options->getClientSecret() ) : '', __( 'Required', 'post-smtp' ) );
 	}
 
 	/**
@@ -507,7 +507,7 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 			$oauthScribe = $transport->getScribe();
 			return $oauthScribe->getCallbackDomain();
 		} catch ( Exception $e ) {
-			return __( 'Error computing your domain root - please enter it manually', Postman::TEXT_DOMAIN );
+			return __( 'Error computing your domain root - please enter it manually', 'post-smtp' );
 		}
 	}
 
@@ -526,28 +526,28 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 	 */
 	public function sender_email_callback() {
 		$inputValue = (null !== $this->options->getEnvelopeSender() ? esc_attr( $this->options->getEnvelopeSender() ) : '');
-		$requiredLabel = __( 'Required', Postman::TEXT_DOMAIN );
-		$envelopeFromMessage = __( 'This address, like the <b>return address</b> printed on an envelope, identifies the account owner to the SMTP server.', Postman::TEXT_DOMAIN );
-		$spfMessage = sprintf( __( 'For reliable delivery, this domain must specify an <a target="_blank" href="%s">SPF record</a> permitting the use of the SMTP server named above.', Postman::TEXT_DOMAIN ), 'https://www.mail-tester.com/spf/' );
+		$requiredLabel = __( 'Required', 'post-smtp' );
+		$envelopeFromMessage = __( 'This address, like the <b>return address</b> printed on an envelope, identifies the account owner to the SMTP server.', 'post-smtp' );
+		$spfMessage = sprintf( __( 'For reliable delivery, this domain must specify an <a target="_blank" href="%s">SPF record</a> permitting the use of the SMTP server named above.', 'post-smtp' ), 'https://www.mail-tester.com/spf/' );
 		printf( '<input type="email" id="input_envelope_sender_email" name="postman_options[envelope_sender]" value="%s" size="40" class="required" placeholder="%s"/> <br/><span class="postman_input_description">%s %s</span>', $inputValue, $requiredLabel, $envelopeFromMessage, $spfMessage );
 	}
 
 	/**
 	 */
 	public function printWizardMailServerHostnameStep() {
-		printf( '<legend>%s</legend>', _x( 'Which host will relay the mail?', 'Wizard Step Title', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'This is the Outgoing (SMTP) Mail Server, or Mail Submission Agent (MSA), which Postman delegates mail delivery to. This server is specific to your email account, and if you don\'t know what to use, ask your email service provider.', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'Note that many WordPress hosts, such as GoDaddy, Bluehost and Dreamhost, require that you use their mail accounts with their mail servers, and prevent you from using others.', Postman::TEXT_DOMAIN ) );
-		printf( '<label for="hostname">%s</label>', __( 'Outgoing Mail Server Hostname', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', _x( 'Which host will relay the mail?', 'Wizard Step Title', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'This is the Outgoing (SMTP) Mail Server, or Mail Submission Agent (MSA), which Postman delegates mail delivery to. This server is specific to your email account, and if you don\'t know what to use, ask your email service provider.', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'Note that many WordPress hosts, such as GoDaddy, Bluehost and Dreamhost, require that you use their mail accounts with their mail servers, and prevent you from using others.', 'post-smtp' ) );
+		printf( '<label for="hostname">%s</label>', __( 'Outgoing Mail Server Hostname', 'post-smtp' ) );
 		print $this->hostname_callback();
 		printf( '<p class="ajax-loader" style="display:none"><img src="%s"/></p>', plugins_url( 'post-smtp/style/ajax-loader.gif' ) );
-		$warning = __( 'Warning', Postman::TEXT_DOMAIN );
+		$warning = __( 'Warning', 'post-smtp' );
 		/* Translators: Where (%s) is the name of the web host */
-		$nonGodaddyDomainMessage = sprintf( __( 'Your email address <b>requires</b> access to a remote SMTP server blocked by %s.', Postman::TEXT_DOMAIN ), 'GoDaddy' );
-		$nonGodaddyDomainMessage .= sprintf( ' %s', __( 'If you have access to cPanel, enable the Remote Mail Exchanger.', Postman::TEXT_DOMAIN ) );
+		$nonGodaddyDomainMessage = sprintf( __( 'Your email address <b>requires</b> access to a remote SMTP server blocked by %s.', 'post-smtp' ), 'GoDaddy' );
+		$nonGodaddyDomainMessage .= sprintf( ' %s', __( 'If you have access to cPanel, enable the Remote Mail Exchanger.', 'post-smtp' ) );
 		printf( '<p id="godaddy_block"><span style="background-color:yellow"><b>%s</b>: %s</span></p>', $warning, $nonGodaddyDomainMessage );
 		/* Translators: Where (%1$s) is the SPF-info URL and (%2$s) is the name of the web host */
-		$godaddyCustomDomainMessage = sprintf( __( 'If you own this domain, make sure it has an <a href="%1$s">SPF record authorizing %2$s</a> as a relay, or you will have delivery problems.', Postman::TEXT_DOMAIN ), 'http://www.mail-tester.com/spf/godaddy', 'GoDaddy' );
+		$godaddyCustomDomainMessage = sprintf( __( 'If you own this domain, make sure it has an <a href="%1$s">SPF record authorizing %2$s</a> as a relay, or you will have delivery problems.', 'post-smtp' ), 'http://www.mail-tester.com/spf/godaddy', 'GoDaddy' );
 		printf( '<p id="godaddy_spf_required"><span style="background-color:yellow"><b>%s</b>: %s</span></p>', $warning, $godaddyCustomDomainMessage );
 	}
 
@@ -575,12 +575,12 @@ class PostmanSmtpModuleTransport extends PostmanAbstractZendModuleTransport impl
 		print '</section>';
 
 		print '<section class="wizard-auth-basic">';
-		printf( '<p class="port-explanation-ssl">%s</p>', __( 'Enter the account credentials.', Postman::TEXT_DOMAIN ) );
-		printf( '<label for="username">%s</label>', __( 'Username', Postman::TEXT_DOMAIN ) );
+		printf( '<p class="port-explanation-ssl">%s</p>', __( 'Enter the account credentials.', 'post-smtp' ) );
+		printf( '<label for="username">%s</label>', __( 'Username', 'post-smtp' ) );
 		print '<br />';
 		print $this->basic_auth_username_callback();
 		print '<br />';
-		printf( '<label for="password">%s</label>', __( 'Password', Postman::TEXT_DOMAIN ) );
+		printf( '<label for="password">%s</label>', __( 'Password', 'post-smtp' ) );
 		print '<br />';
 		print $this->basic_auth_password_callback();
 		print '</section>';

--- a/Postman/Postman-Mail/PostmanTransportRegistry.php
+++ b/Postman/Postman-Mail/PostmanTransportRegistry.php
@@ -231,18 +231,18 @@ class PostmanTransportRegistry {
 			if ( PostmanOptions::getInstance()->getRunMode() != PostmanOptions::RUN_MODE_PRODUCTION ) {
 				return array(
 					'error' => true,
-					'message' => __( 'Postman is in <em>non-Production</em> mode and is dumping all emails.', Postman::TEXT_DOMAIN ),
+					'message' => __( 'Postman is in <em>non-Production</em> mode and is dumping all emails.', 'post-smtp' ),
 				);
 			} else {
 				return array(
 					'error' => false,
-					'message' => __( 'Postman is configured.', Postman::TEXT_DOMAIN ),
+					'message' => __( 'Postman is configured.', 'post-smtp' ),
 				);
 			}
 		} else {
 			return array(
 				'error' => true,
-				'message' => __( 'Postman is <em>not</em> configured and is mimicking out-of-the-box WordPress email delivery.', Postman::TEXT_DOMAIN ),
+				'message' => __( 'Postman is <em>not</em> configured and is mimicking out-of-the-box WordPress email delivery.', 'post-smtp' ),
 			);
 		}
 	}

--- a/Postman/Postman-Mail/PostmanWooCommerce.php
+++ b/Postman/Postman-Mail/PostmanWooCommerce.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 
 			return array(
 
-				array( 'title' => __( 'Email notifications', Postman::TEXT_DOMAIN ),  'desc' => __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.', Postman::TEXT_DOMAIN ), 'type' => 'title', 'id' => 'email_notification_settings' ),
+				array( 'title' => __( 'Email notifications', 'post-smtp' ),  'desc' => __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.', 'post-smtp' ), 'type' => 'title', 'id' => 'email_notification_settings' ),
 
 				array( 'type' => 'email_notification' ),
 
@@ -36,11 +36,11 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 
 				array( 'type' => 'sectionend', 'id' => 'email_recipient_options' ),
 
-				array( 'title' => __( 'Email sender options', Postman::TEXT_DOMAIN ), 'type' => 'title', 'desc' => '', 'id' => 'email_options' ),
+				array( 'title' => __( 'Email sender options', 'post-smtp' ), 'type' => 'title', 'desc' => '', 'id' => 'email_options' ),
 
 				array(
-					'title'    => __( '"From" name', Postman::TEXT_DOMAIN ),
-					'desc'     => __( 'How the sender name appears in outgoing WooCommerce emails.', Postman::TEXT_DOMAIN ),
+					'title'    => __( '"From" name', 'post-smtp' ),
+					'desc'     => __( 'How the sender name appears in outgoing WooCommerce emails.', 'post-smtp' ),
 					'id'       => 'woocommerce_email_from_name',
 					'type'     => 'text',
 					'css'      => 'min-width:300px;',
@@ -50,8 +50,8 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 				),
 
 				array(
-					'title'             => __( '"From" address', Postman::TEXT_DOMAIN ),
-					'desc'              => __( 'This is overided by the account configured on Post SMTP plugin configuration.', Postman::TEXT_DOMAIN ),
+					'title'             => __( '"From" address', 'post-smtp' ),
+					'desc'              => __( 'This is overided by the account configured on Post SMTP plugin configuration.', 'post-smtp' ),
 					'id'                => 'woocommerce_email_from_address',
 					'type'              => 'email',
 					'custom_attributes' => array(
@@ -66,26 +66,26 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 
 				array( 'type' => 'sectionend', 'id' => 'email_options' ),
 
-				array( 'title' => __( 'Email template', Postman::TEXT_DOMAIN ), 'type' => 'title', 'desc' => sprintf( __( 'This section lets you customize the WooCommerce emails. <a href="%s" target="_blank">Click here to preview your email template</a>.', Postman::TEXT_DOMAIN ), wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ), 'id' => 'email_template_options' ),
+				array( 'title' => __( 'Email template', 'post-smtp' ), 'type' => 'title', 'desc' => sprintf( __( 'This section lets you customize the WooCommerce emails. <a href="%s" target="_blank">Click here to preview your email template</a>.', 'post-smtp' ), wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ), 'id' => 'email_template_options' ),
 
 				array(
-					'title'       => __( 'Header image', Postman::TEXT_DOMAIN ),
-					'desc'        => __( 'URL to an image you want to show in the email header. Upload images using the media uploader (Admin > Media).', Postman::TEXT_DOMAIN ),
+					'title'       => __( 'Header image', 'post-smtp' ),
+					'desc'        => __( 'URL to an image you want to show in the email header. Upload images using the media uploader (Admin > Media).', 'post-smtp' ),
 					'id'          => 'woocommerce_email_header_image',
 					'type'        => 'text',
 					'css'         => 'min-width:300px;',
-					'placeholder' => __( 'N/A', Postman::TEXT_DOMAIN ),
+					'placeholder' => __( 'N/A', 'post-smtp' ),
 					'default'     => '',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),
 
 				array(
-					'title'       => __( 'Footer text', Postman::TEXT_DOMAIN ),
-					'desc'        => __( 'The text to appear in the footer of WooCommerce emails.', Postman::TEXT_DOMAIN ),
+					'title'       => __( 'Footer text', 'post-smtp' ),
+					'desc'        => __( 'The text to appear in the footer of WooCommerce emails.', 'post-smtp' ),
 					'id'          => 'woocommerce_email_footer_text',
 					'css'         => 'width:300px; height: 75px;',
-					'placeholder' => __( 'N/A', Postman::TEXT_DOMAIN ),
+					'placeholder' => __( 'N/A', 'post-smtp' ),
 					'type'        => 'textarea',
 					/* translators: %s: site name */
 					'default'     => get_bloginfo( 'name', 'display' ),
@@ -94,9 +94,9 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 				),
 
 				array(
-					'title'    => __( 'Base color', Postman::TEXT_DOMAIN ),
+					'title'    => __( 'Base color', 'post-smtp' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The base color for WooCommerce email templates. Default %s.', Postman::TEXT_DOMAIN ), '<code>#96588a</code>' ),
+					'desc'     => sprintf( __( 'The base color for WooCommerce email templates. Default %s.', 'post-smtp' ), '<code>#96588a</code>' ),
 					'id'       => 'woocommerce_email_base_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
@@ -106,9 +106,9 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 				),
 
 				array(
-					'title'    => __( 'Background color', Postman::TEXT_DOMAIN ),
+					'title'    => __( 'Background color', 'post-smtp' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The background color for WooCommerce email templates. Default %s.', Postman::TEXT_DOMAIN ), '<code>#f7f7f7</code>' ),
+					'desc'     => sprintf( __( 'The background color for WooCommerce email templates. Default %s.', 'post-smtp' ), '<code>#f7f7f7</code>' ),
 					'id'       => 'woocommerce_email_background_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
@@ -118,9 +118,9 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 				),
 
 				array(
-					'title'    => __( 'Body background color', Postman::TEXT_DOMAIN ),
+					'title'    => __( 'Body background color', 'post-smtp' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The main body background color. Default %s.', Postman::TEXT_DOMAIN ), '<code>#ffffff</code>' ),
+					'desc'     => sprintf( __( 'The main body background color. Default %s.', 'post-smtp' ), '<code>#ffffff</code>' ),
 					'id'       => 'woocommerce_email_body_background_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
@@ -130,9 +130,9 @@ if ( ! class_exists( 'PostmanWoocommerce' ) ) {
 				),
 
 				array(
-					'title'    => __( 'Body text color', Postman::TEXT_DOMAIN ),
+					'title'    => __( 'Body text color', 'post-smtp' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The main body text color. Default %s.', Postman::TEXT_DOMAIN ), '<code>#3c3c3c</code>' ),
+					'desc'     => sprintf( __( 'The main body text color. Default %s.', 'post-smtp' ), '<code>#3c3c3c</code>' ),
 					'id'       => 'woocommerce_email_text_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',

--- a/Postman/Postman-Mail/PostmanZendMailEngine.php
+++ b/Postman/Postman-Mail/PostmanZendMailEngine.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'PostmanZendMailEngine' ) ) {
 				$message = $e->getMessage();
 				if ( $e->getCode() == 334 ) {
 					// replace the unusable Google message with a better one in the case of code 334
-					$message = sprintf( __( 'Communication Error [334] - make sure the Envelope From email is the same account used to create the Client ID.', Postman::TEXT_DOMAIN ) );
+					$message = sprintf( __( 'Communication Error [334] - make sure the Envelope From email is the same account used to create the Client ID.', 'post-smtp' ) );
 				}
 				// create a new exception
 				$newException = new Exception( $message, $e->getCode() );

--- a/Postman/Postman-Send-Test-Email/PostmanSendTestEmailController.php
+++ b/Postman/Postman-Send-Test-Email/PostmanSendTestEmailController.php
@@ -90,7 +90,7 @@ class PostmanSendTestEmailController {
 	 * Register the Email Test screen
 	 */
 	public function addEmailTestSubmenu() {
-		$page = add_submenu_page( null, sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ) ), __( 'Postman SMTP', Postman::TEXT_DOMAIN ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanSendTestEmailController::EMAIL_TEST_SLUG, array(
+		$page = add_submenu_page( null, sprintf( __( '%s Setup', 'post-smtp' ), __( 'Postman SMTP', 'post-smtp' ) ), __( 'Postman SMTP', 'post-smtp' ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanSendTestEmailController::EMAIL_TEST_SLUG, array(
 				$this,
 				'outputTestEmailContent',
 		) );
@@ -110,11 +110,11 @@ class PostmanSendTestEmailController {
 		wp_enqueue_script( 'postman_test_email_wizard_script' );
 		wp_localize_script( PostmanViewController::POSTMAN_SCRIPT, 'postman_email_test', array(
 				'recipient' => '#' . self::RECIPIENT_EMAIL_FIELD_NAME,
-				'not_started' => _x( 'In Outbox', 'Email Test Status', Postman::TEXT_DOMAIN ),
-				'sending' => _x( 'Sending...', 'Email Test Status', Postman::TEXT_DOMAIN ),
-				'success' => _x( 'Success', 'Email Test Status', Postman::TEXT_DOMAIN ),
-				'failed' => _x( 'Failed', 'Email Test Status', Postman::TEXT_DOMAIN ),
-				'ajax_error' => __( 'Ajax Error', Postman::TEXT_DOMAIN ),
+				'not_started' => _x( 'In Outbox', 'Email Test Status', 'post-smtp' ),
+				'sending' => _x( 'Sending...', 'Email Test Status', 'post-smtp' ),
+				'success' => _x( 'Success', 'Email Test Status', 'post-smtp' ),
+				'failed' => _x( 'Failed', 'Email Test Status', 'post-smtp' ),
+				'ajax_error' => __( 'Ajax Error', 'post-smtp' ),
 		) );
 	}
 
@@ -123,42 +123,42 @@ class PostmanSendTestEmailController {
 	public function outputTestEmailContent() {
 		print '<div class="wrap">';
 
-		PostmanViewController::outputChildPageHeader( __( 'Send a Test Email', Postman::TEXT_DOMAIN ) );
+		PostmanViewController::outputChildPageHeader( __( 'Send a Test Email', 'post-smtp' ) );
 
 		printf( '<form id="postman_test_email_wizard" method="post" action="%s">', PostmanUtils::getSettingsPageUrl() );
 
 		// Step 1
-		printf( '<h5>%s</h5>', __( 'Specify the Recipient', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Specify the Recipient', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', __( 'Who is this message going to?', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s', __( 'This utility allows you to send an email message for testing.', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', __( 'Who is this message going to?', 'post-smtp' ) );
+		printf( '<p>%s', __( 'This utility allows you to send an email message for testing.', 'post-smtp' ) );
 		print ' ';
 		/* translators: where %d is an amount of time, in seconds */
-		printf( '%s</p>', sprintf( _n( 'If there is a problem, Postman will give up after %d second.', 'If there is a problem, Postman will give up after %d seconds.', $this->options->getReadTimeout(), Postman::TEXT_DOMAIN ), $this->options->getReadTimeout() ) );
-		printf( '<label for="postman_test_options[test_email]">%s</label>', _x( 'Recipient Email Address', 'Configuration Input Field', Postman::TEXT_DOMAIN ) );
+		printf( '%s</p>', sprintf( _n( 'If there is a problem, Postman will give up after %d second.', 'If there is a problem, Postman will give up after %d seconds.', $this->options->getReadTimeout(), 'post-smtp' ), $this->options->getReadTimeout() ) );
+		printf( '<label for="postman_test_options[test_email]">%s</label>', _x( 'Recipient Email Address', 'Configuration Input Field', 'post-smtp' ) );
 		print $this->test_email_callback();
 		print '</fieldset>';
 
 		// Step 2
-		printf( '<h5>%s</h5>', __( 'Send The Message', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Send The Message', 'post-smtp' ) );
 		print '<fieldset>';
 		print '<legend>';
-		print __( 'Sending the message:', Postman::TEXT_DOMAIN );
-		printf( ' <span id="postman_test_message_status">%s</span>', _x( 'In Outbox', 'Email Test Status', Postman::TEXT_DOMAIN ) );
+		print __( 'Sending the message:', 'post-smtp' );
+		printf( ' <span id="postman_test_message_status">%s</span>', _x( 'In Outbox', 'Email Test Status', 'post-smtp' ) );
 		print '</legend>';
 		print '<section>';
-		printf( '<p><label>%s</label></p>', __( 'Status', Postman::TEXT_DOMAIN ) );
+		printf( '<p><label>%s</label></p>', __( 'Status', 'post-smtp' ) );
 		print '<textarea id="postman_test_message_error_message" readonly="readonly" cols="65" rows="4"></textarea>';
 		print '</section>';
 		print '</fieldset>';
 
 		// Step 3
-		printf( '<h5>%s</h5>', __( 'Session Transcript', Postman::TEXT_DOMAIN ) );
+		printf( '<h5>%s</h5>', __( 'Session Transcript', 'post-smtp' ) );
 		print '<fieldset>';
-		printf( '<legend>%s</legend>', __( 'Examine the Session Transcript if you need to.', Postman::TEXT_DOMAIN ) );
-		printf( '<p>%s</p>', __( 'This is the conversation between Postman and the mail server. It can be useful for diagnosing problems. <b>DO NOT</b> post it on-line, it may contain your account password.', Postman::TEXT_DOMAIN ) );
+		printf( '<legend>%s</legend>', __( 'Examine the Session Transcript if you need to.', 'post-smtp' ) );
+		printf( '<p>%s</p>', __( 'This is the conversation between Postman and the mail server. It can be useful for diagnosing problems. <b>DO NOT</b> post it on-line, it may contain your account password.', 'post-smtp' ) );
 		print '<section>';
-		printf( '<p><label for="postman_test_message_transcript">%s</label></p>', __( 'Session Transcript', Postman::TEXT_DOMAIN ) );
+		printf( '<p><label for="postman_test_message_transcript">%s</label></p>', __( 'Session Transcript', 'post-smtp' ) );
 		print '<textarea readonly="readonly" id="postman_test_message_transcript" cols="65" rows="8"></textarea>';
 		print '</section>';
 		print '</fieldset>';
@@ -206,7 +206,7 @@ class PostmanSendTestEmailAjaxController extends PostmanAbstractAjaxHandler {
 		$serverName = PostmanUtils::postmanGetServerName();
 
 		/* translators: where %s is the domain name of the site */
-		$subject = sprintf( _x( 'Postman SMTP Test (%s)', 'Test Email Subject', Postman::TEXT_DOMAIN ), $serverName );
+		$subject = sprintf( _x( 'Postman SMTP Test (%s)', 'Test Email Subject', 'post-smtp' ), $serverName );
 
 		// Postman API: indicate to Postman this is just for testing
 		add_filter( 'postman_test_email', array(
@@ -236,7 +236,7 @@ class PostmanSendTestEmailAjaxController extends PostmanAbstractAjaxHandler {
 		if ( $success ) {
 			$this->logger->debug( 'Test Email delivered to server' );
 			// the message was sent successfully, generate an appropriate message for the user
-			$statusMessage = sprintf( __( 'Your message was delivered (%d ms) to the SMTP server! Congratulations :)', Postman::TEXT_DOMAIN ), $result ['time'] );
+			$statusMessage = sprintf( __( 'Your message was delivered (%d ms) to the SMTP server! Congratulations :)', 'post-smtp' ), $result ['time'] );
 
 						$this->logger->debug( 'statusmessage: ' . $statusMessage );
 
@@ -292,9 +292,9 @@ class PostmanSendTestEmailAjaxController extends PostmanAbstractAjaxHandler {
 		// English - Mandarin - French - Hindi - Spanish - Portuguese - Russian - Japanese
 		// http://www.pinyin.info/tools/converter/chars2uninumbers.html
 		$greeting = 'Hello! - &#20320;&#22909; - Bonjour! - &#2344;&#2350;&#2360;&#2381;&#2340;&#2375; - ¡Hola! - Ol&#225; - &#1055;&#1088;&#1080;&#1074;&#1077;&#1090;! - &#20170;&#26085;&#12399;';
-		$sentBy = sprintf( _x( 'Sent by Postman %s', 'Test Email Tagline', Postman::TEXT_DOMAIN ), $pluginData ['version'] );
-		$imageSource = __( 'Image source', Postman::TEXT_DOMAIN );
-		$withPermission = __( 'Used with permission', Postman::TEXT_DOMAIN );
+		$sentBy = sprintf( _x( 'Sent by Postman %s', 'Test Email Tagline', 'post-smtp' ), $pluginData ['version'] );
+		$imageSource = __( 'Image source', 'post-smtp' );
+		$withPermission = __( 'Used with permission', 'post-smtp' );
 		$messageArray = array(
 				'Content-Type: text/plain; charset = "UTF-8"',
 				'Content-Transfer-Encoding: 8bit',

--- a/Postman/Postman.php
+++ b/Postman/Postman.php
@@ -19,6 +19,14 @@ class Postman {
 	const ADMINISTRATOR_ROLE_NAME = 'administrator';
 	const MANAGE_POSTMAN_CAPABILITY_NAME = 'manage_postman_smtp';
 	const MANAGE_POSTMAN_CAPABILITY_LOGS = 'manage_postman_logs';
+
+	/**
+	 * Use the text domain directly instead of this constant, as it 
+	 * causes issues with https://translate.wordpress.org.
+	 * 
+	 * @deprecated
+	 * @see https://github.com/yehudah/Post-SMTP/issues/1#issuecomment-421940923
+	 */
 	const TEXT_DOMAIN = 'post-smtp';
 
 	private $logger;
@@ -60,7 +68,7 @@ class Postman {
 
 		// get plugin metadata - alternative to get_plugin_data
 		$this->pluginData = array(
-				'name' => __( 'Postman SMTP', Postman::TEXT_DOMAIN ),
+				'name' => __( 'Postman SMTP', 'post-smtp' ),
 				'version' => $version,
 		);
 
@@ -163,9 +171,9 @@ class Postman {
 
 	public function post_smtp_wpml_admin_notice() {
 		$class = 'notice notice-error';
-		$title =  __( 'Post SMTP notice!', Postman::TEXT_DOMAIN );
-		$intro = __( 'WPML is installed and has a known bug with Post SMTP and few other plugins - you better upgrade, but we can try to fix it.', Postman::TEXT_DOMAIN );
-		$text = __( 'Click here to fix', Postman::TEXT_DOMAIN );
+		$title =  __( 'Post SMTP notice!', 'post-smtp' );
+		$intro = __( 'WPML is installed and has a known bug with Post SMTP and few other plugins - you better upgrade, but we can try to fix it.', 'post-smtp' );
+		$text = __( 'Click here to fix', 'post-smtp' );
 		$message = '<br><a href="' . esc_url( add_query_arg( 'action', 'postman_fix_wpml', get_permalink() ) ) . '">' . $text . '</a>';
 
 		printf( '<div class="%1$s"><h2>%2$s</h2><p>%3$s</p><p>%4$s</p></div>', esc_attr( $class ), $title, $intro, $message );
@@ -305,7 +313,7 @@ class Postman {
 				// I've adopted their error message as well, for shits and giggles .... :D
 				$reflFunc = new ReflectionFunction( 'wp_mail' );
 
-				$message = __( 'Postman: wp_mail has been declared by another plugin or theme, so you won\'t be able to use Postman until the conflict is resolved.', Postman::TEXT_DOMAIN );
+				$message = __( 'Postman: wp_mail has been declared by another plugin or theme, so you won\'t be able to use Postman until the conflict is resolved.', 'post-smtp' );
 				$plugin_full_path = $reflFunc->getFileName();
 
 				if ( strpos( $plugin_full_path, 'plugins' ) !== false ) {
@@ -382,8 +390,8 @@ class Postman {
 			}
 			$msg = PostmanTransportRegistry::getInstance()->getReadyMessage();
 			$message = sprintf( $msg['message'] );
-			$goToSettings = sprintf( '<a href="%s">%s</a>', PostmanUtils::getSettingsPageUrl(), __( 'Settings', Postman::TEXT_DOMAIN ) );
-			$goToEmailLog = sprintf( '%s', _x( 'Email Log', 'The log of Emails that have been delivered', Postman::TEXT_DOMAIN ) );
+			$goToSettings = sprintf( '<a href="%s">%s</a>', PostmanUtils::getSettingsPageUrl(), __( 'Settings', 'post-smtp' ) );
+			$goToEmailLog = sprintf( '%s', _x( 'Email Log', 'The log of Emails that have been delivered', 'post-smtp' ) );
 			if ( PostmanOptions::getInstance()->isMailLoggingEnabled() ) {
 				$goToEmailLog = sprintf( '<a href="%s">%s</a>', PostmanUtils::getEmailLogPageUrl(), $goToEmailLog );
 			}
@@ -433,12 +441,12 @@ class Postman {
 		$shortLocale = substr( get_locale(), 0, 2 );
 		if ( $shortLocale != 'en' ) {
 			$langDir = 'post-smtp/Postman/languages';
-			$success = load_plugin_textdomain( Postman::TEXT_DOMAIN, false, $langDir );
+			$success = load_plugin_textdomain( 'post-smtp', false, $langDir );
 			if ( $this->logger->isDebug() ) {
 				if ( $success ) {
 					$this->logger->debug( sprintf( 'local translation file loaded for locale=%s', get_locale() ) );
 				} else {
-					$this->logger->debug( sprintf( 'failed to load local translation file: locale=%s file=%s/%s-%s.mo', get_locale(), $langDir, Postman::TEXT_DOMAIN, get_locale() ) );
+					$this->logger->debug( sprintf( 'failed to load local translation file: locale=%s file=%s/%s-%s.mo', get_locale(), $langDir, 'post-smtp', get_locale() ) );
 				}
 			}
 		}

--- a/Postman/PostmanAdminController.php
+++ b/Postman/PostmanAdminController.php
@@ -111,7 +111,7 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 				// do a redirect on the init hook
 				$this->registerInitFunction( 'handleSuccessfulSave' );
 				// add a saved message to be shown after the redirect
-				$this->messageHandler->addMessage( _x( 'Settings saved.', 'The plugin successfully saved new settings.', Postman::TEXT_DOMAIN ) );
+				$this->messageHandler->addMessage( _x( 'Settings saved.', 'The plugin successfully saved new settings.', 'post-smtp' ) );
 				return;
 			} else {
 				// unset the action in the failed case as well
@@ -162,11 +162,11 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 		    ?>
             <input type="hidden" name="<?php echo PostmanOptions::POSTMAN_NETWORK_OPTIONS; ?>[post_smtp_global_settings]" value="null">
             <input type="hidden" name="<?php echo PostmanOptions::POSTMAN_NETWORK_OPTIONS; ?>[post_smtp_allow_overwrite]" value="null">
-            <h2><?php _e( 'Post SMTP Settings', Postman::TEXT_DOMAIN ); ?></h2>
+            <h2><?php _e( 'Post SMTP Settings', 'post-smtp' ); ?></h2>
             <table id="menu" class="form-table">
                 <tr>
                     <th scope="row">
-                        <?php _e( 'Enable global settings', Postman::TEXT_DOMAIN ); ?>
+                        <?php _e( 'Enable global settings', 'post-smtp' ); ?>
                     </th>
                     <td>
                         <?php $checked = checked( $options['post_smtp_global_settings'], 1, false ); ?>
@@ -177,14 +177,14 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
                                    <?php echo $checked; ?>
                             >
                             <p class="description">
-                                <?php _e('Same settings as the main site/blog (id:1)', Postman::TEXT_DOMAIN ); ?>
+                                <?php _e('Same settings as the main site/blog (id:1)', 'post-smtp' ); ?>
                             </p>
                         </label>
                     </td>
                 </tr>
                 <tr>
                     <th scope="row">
-                        <?php _e( 'Allow user to load saved options', Postman::TEXT_DOMAIN ); ?>
+                        <?php _e( 'Allow user to load saved options', 'post-smtp' ); ?>
                     </th>
                     <td>
                         <?php $checked = checked( $options['post_smtp_allow_overwrite'], 1, false ); ?>
@@ -252,7 +252,7 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 			foreach ( $states as $state ) {
 				if ( ! $state ['ready'] ) {
 					/* Translators: where %1$s is the name of the library */
-					$message = sprintf( __( 'This PHP installation requires the <b>%1$s</b> library.', Postman::TEXT_DOMAIN ), $state ['name'] );
+					$message = sprintf( __( 'This PHP installation requires the <b>%1$s</b> library.', 'post-smtp' ), $state ['name'] );
 					if ( $state ['required'] ) {
 						$this->messageHandler->addError( $message );
 					} else {
@@ -299,8 +299,8 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 			// only administrators should be able to trigger this
 			if ( PostmanUtils::isAdmin() ) {
 				$mylinks = array(
-						sprintf( '<a href="%s" class="postman_settings">%s</a>', PostmanUtils::getSettingsPageUrl(), __( 'Settings', Postman::TEXT_DOMAIN ) ),
-						sprintf( '<a href="%s" class="postman_settings">%s</a>', 'https://postmansmtp.com', __( 'Visit us', Postman::TEXT_DOMAIN ) ),
+						sprintf( '<a href="%s" class="postman_settings">%s</a>', PostmanUtils::getSettingsPageUrl(), __( 'Settings', 'post-smtp' ) ),
+						sprintf( '<a href="%s" class="postman_settings">%s</a>', 'https://postmansmtp.com', __( 'Visit us', 'post-smtp' ) ),
 				);
 				return array_merge( $mylinks, $links );
 			}
@@ -328,7 +328,7 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 				$success = false;
 			}
 			if ( ! $success ) {
-				$this->messageHandler->addError( __( 'There was an error importing the data.', Postman::TEXT_DOMAIN ) );
+				$this->messageHandler->addError( __( 'There was an error importing the data.', 'post-smtp' ) );
 				$this->logger->error( 'There was an error importing the data' );
 			}
 			PostmanUtils::redirect( PostmanUtils::POSTMAN_HOME_PAGE_RELATIVE_URL );
@@ -345,7 +345,7 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 				delete_option( PostmanAdminController::TEST_OPTIONS );
 				$logPurger = new PostmanEmailLogPurger();
 				$logPurger->removeAll();
-				$this->messageHandler->addMessage( __( 'Plugin data was removed.', Postman::TEXT_DOMAIN ) );
+				$this->messageHandler->addMessage( __( 'Plugin data was removed.', 'post-smtp' ) );
 				PostmanUtils::redirect( PostmanUtils::POSTMAN_HOME_PAGE_RELATIVE_URL );
 			}
 		}
@@ -369,16 +369,16 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 					$logger->debug( 'Authorization successful' );
 					// save to database
 					$authorizationToken->save();
-					$this->messageHandler->addMessage( __( 'The OAuth 2.0 authorization was successful. Ready to send e-mail.', Postman::TEXT_DOMAIN ) );
+					$this->messageHandler->addMessage( __( 'The OAuth 2.0 authorization was successful. Ready to send e-mail.', 'post-smtp' ) );
 				} else {
-					$this->messageHandler->addError( __( 'Your email provider did not grant Postman permission. Try again.', Postman::TEXT_DOMAIN ) );
+					$this->messageHandler->addError( __( 'Your email provider did not grant Postman permission. Try again.', 'post-smtp' ) );
 				}
 			} catch ( PostmanStateIdMissingException $e ) {
-				$this->messageHandler->addError( __( 'The grant code from Google had no accompanying state and may be a forgery', Postman::TEXT_DOMAIN ) );
+				$this->messageHandler->addError( __( 'The grant code from Google had no accompanying state and may be a forgery', 'post-smtp' ) );
 			} catch ( Exception $e ) {
 				$logger->error( 'Error: ' . get_class( $e ) . ' code=' . $e->getCode() . ' message=' . $e->getMessage() );
 				/* translators: %s is the error message */
-				$this->messageHandler->addError( sprintf( __( 'Error authenticating with this Client ID. [%s]', Postman::TEXT_DOMAIN ), '<em>' . $e->getMessage() . '</em>' ) );
+				$this->messageHandler->addError( sprintf( __( 'Error authenticating with this Client ID. [%s]', 'post-smtp' ), '<em>' . $e->getMessage() . '</em>' ) );
 			}
 
 			// clean-up

--- a/Postman/PostmanConfigTextHelper.php
+++ b/Postman/PostmanConfigTextHelper.php
@@ -28,8 +28,8 @@ if ( ! class_exists( 'PostmanAbstractConfigTextHelper' ) ) {
 	 */
 	abstract class PostmanAbstractConfigTextHelper implements PostmanConfigTextHelper {
 		public function getOAuthHelp() {
-			$attention = __( 'Attention', Postman::TEXT_DOMAIN );
-			$errorMessage = sprintf( __('Check this article how to configure Gmail/Gsuite OAuth:<a href="%1$s" target="_blank">Read Here</a>', Postman::TEXT_DOMAIN ), 'https://postmansmtp.com/how-to-configure-post-smtp-with-gmailgsuite-using-oauth/' );
+			$attention = __( 'Attention', 'post-smtp' );
+			$errorMessage = sprintf( __('Check this article how to configure Gmail/Gsuite OAuth:<a href="%1$s" target="_blank">Read Here</a>', 'post-smtp' ), 'https://postmansmtp.com/how-to-configure-post-smtp-with-gmailgsuite-using-oauth/' );
 			$text = sprintf( '<b style="color:red">%s!</b> %s', $attention, $errorMessage );
 			
 			return $text;
@@ -48,7 +48,7 @@ if ( ! class_exists( 'PostmanAbstractConfigTextHelper' ) ) {
 		}
 		public function getRequestPermissionLinkText() {
 			/* translators: where %s is the Email Service Owner (e.g. Google, Microsoft or Yahoo) */
-			return sprintf( _x( 'Grant permission with %s', 'Command to initiate OAuth authentication', Postman::TEXT_DOMAIN ), $this->getOwnerName() );
+			return sprintf( _x( 'Grant permission with %s', 'Command to initiate OAuth authentication', 'post-smtp' ), $this->getOwnerName() );
 		}
 	}
 }
@@ -74,35 +74,35 @@ if ( ! class_exists( 'PostmanGoogleOAuthScribe' ) ) {
 		}
 		public function getClientIdLabel() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', Postman::TEXT_DOMAIN );
+			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', 'post-smtp' );
 		}
 		public function getClientSecretLabel() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', Postman::TEXT_DOMAIN );
+			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', 'post-smtp' );
 		}
 		public function getCallbackUrlLabel() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Authorized redirect URI', 'Name of the Application Callback URI', Postman::TEXT_DOMAIN );
+			return _x( 'Authorized redirect URI', 'Name of the Application Callback URI', 'post-smtp' );
 		}
 		public function getCallbackDomainLabel() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Authorized JavaScript origins', 'Name of the Application Callback Domain', Postman::TEXT_DOMAIN );
+			return _x( 'Authorized JavaScript origins', 'Name of the Application Callback Domain', 'post-smtp' );
 		}
 		public function getOwnerName() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Google', 'Name of the email service owner', Postman::TEXT_DOMAIN );
+			return _x( 'Google', 'Name of the email service owner', 'post-smtp' );
 		}
 		public function getServiceName() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Gmail', 'Name of the email service', Postman::TEXT_DOMAIN );
+			return _x( 'Gmail', 'Name of the email service', 'post-smtp' );
 		}
 		public function getApplicationDescription() {
 			/* Translators: This description is specific to Google */
-			return _x( 'a Client ID for web application', 'Description of the email service OAuth 2.0 Application', Postman::TEXT_DOMAIN );
+			return _x( 'a Client ID for web application', 'Description of the email service OAuth 2.0 Application', 'post-smtp' );
 		}
 		public function getApplicationPortalName() {
 			/* Translators: This description is specific to Google */
-			return _x( 'Google Developers Console Gmail Wizard', 'Name of the email service portal', Postman::TEXT_DOMAIN );
+			return _x( 'Google Developers Console Gmail Wizard', 'Name of the email service portal', 'post-smtp' );
 		}
 		public function getApplicationPortalUrl() {
 			return 'https://www.google.com/accounts/Logout?continue=https://console.developers.google.com/start/api?id=gmail';
@@ -136,35 +136,35 @@ if ( ! class_exists( 'PostmanMicrosoftOAuthScribe' ) ) {
 		}
 		public function getClientIdLabel() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', Postman::TEXT_DOMAIN );
+			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', 'post-smtp' );
 		}
 		public function getClientSecretLabel() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', Postman::TEXT_DOMAIN );
+			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', 'post-smtp' );
 		}
 		public function getCallbackUrlLabel() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Redirect URL', 'Name of the Application Callback URI', Postman::TEXT_DOMAIN );
+			return _x( 'Redirect URL', 'Name of the Application Callback URI', 'post-smtp' );
 		}
 		public function getCallbackDomainLabel() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Root Domain', 'Name of the Application Callback Domain', Postman::TEXT_DOMAIN );
+			return _x( 'Root Domain', 'Name of the Application Callback Domain', 'post-smtp' );
 		}
 		public function getOwnerName() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Microsoft', 'Name of the email service owner', Postman::TEXT_DOMAIN );
+			return _x( 'Microsoft', 'Name of the email service owner', 'post-smtp' );
 		}
 		public function getServiceName() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Outlook.com', 'Name of the email service', Postman::TEXT_DOMAIN );
+			return _x( 'Outlook.com', 'Name of the email service', 'post-smtp' );
 		}
 		public function getApplicationDescription() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'an Application', 'Description of the email service OAuth 2.0 Application', Postman::TEXT_DOMAIN );
+			return _x( 'an Application', 'Description of the email service OAuth 2.0 Application', 'post-smtp' );
 		}
 		public function getApplicationPortalName() {
 			/* Translators: This description is specific to Microsoft */
-			return _x( 'Microsoft Developer Center', 'Name of the email service portal', Postman::TEXT_DOMAIN );
+			return _x( 'Microsoft Developer Center', 'Name of the email service portal', 'post-smtp' );
 		}
 		public function getApplicationPortalUrl() {
 			return 'https://account.live.com/developers/applications/index';
@@ -198,35 +198,35 @@ if ( ! class_exists( 'PostmanYahooOAuthScribe' ) ) {
 		}
 		public function getClientIdLabel() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', Postman::TEXT_DOMAIN );
+			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', 'post-smtp' );
 		}
 		public function getClientSecretLabel() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', Postman::TEXT_DOMAIN );
+			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', 'post-smtp' );
 		}
 		public function getCallbackUrlLabel() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Home Page URL', 'Name of the Application Callback URI', Postman::TEXT_DOMAIN );
+			return _x( 'Home Page URL', 'Name of the Application Callback URI', 'post-smtp' );
 		}
 		public function getCallbackDomainLabel() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Callback Domain', 'Name of the Application Callback Domain', Postman::TEXT_DOMAIN );
+			return _x( 'Callback Domain', 'Name of the Application Callback Domain', 'post-smtp' );
 		}
 		public function getOwnerName() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Yahoo', 'Name of the email service owner', Postman::TEXT_DOMAIN );
+			return _x( 'Yahoo', 'Name of the email service owner', 'post-smtp' );
 		}
 		public function getServiceName() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Yahoo Mail', 'Name of the email service', Postman::TEXT_DOMAIN );
+			return _x( 'Yahoo Mail', 'Name of the email service', 'post-smtp' );
 		}
 		public function getApplicationDescription() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'an Application', 'Description of the email service OAuth 2.0 Application', Postman::TEXT_DOMAIN );
+			return _x( 'an Application', 'Description of the email service OAuth 2.0 Application', 'post-smtp' );
 		}
 		public function getApplicationPortalName() {
 			/* Translators: This description is specific to Yahoo */
-			return _x( 'Yahoo Developer Network', 'Name of the email service portal', Postman::TEXT_DOMAIN );
+			return _x( 'Yahoo Developer Network', 'Name of the email service portal', 'post-smtp' );
 		}
 		public function getApplicationPortalUrl() {
 			return 'https://developer.yahoo.com/apps/';
@@ -255,7 +255,7 @@ if ( ! class_exists( 'PostmanNonOAuthScribe' ) ) {
 			return PostmanUtils::endsWith( $this->hostname, 'yahoo.com' );
 		}
 		public function getOAuthHelp() {
-			$text = __( 'Enter an Outgoing Mail Server with OAuth2 capabilities.', Postman::TEXT_DOMAIN );
+			$text = __( 'Enter an Outgoing Mail Server with OAuth2 capabilities.', 'post-smtp' );
 			return sprintf( '<span style="color:red" class="normal">%s</span>', $text );
 		}
 		public function getCallbackUrl() {
@@ -265,16 +265,16 @@ if ( ! class_exists( 'PostmanNonOAuthScribe' ) ) {
 			return '';
 		}
 		public function getClientIdLabel() {
-			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', Postman::TEXT_DOMAIN );
+			return _x( 'Client ID', 'Name of the OAuth 2.0 Client ID', 'post-smtp' );
 		}
 		public function getClientSecretLabel() {
-			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', Postman::TEXT_DOMAIN );
+			return _x( 'Client Secret', 'Name of the OAuth 2.0 Client Secret', 'post-smtp' );
 		}
 		public function getCallbackUrlLabel() {
-			return _x( 'Redirect URI', 'Name of the Application Callback URI', Postman::TEXT_DOMAIN );
+			return _x( 'Redirect URI', 'Name of the Application Callback URI', 'post-smtp' );
 		}
 		public function getCallbackDomainLabel() {
-			return _x( 'Website Domain', 'Name of the Application Callback Domain', Postman::TEXT_DOMAIN );
+			return _x( 'Website Domain', 'Name of the Application Callback Domain', 'post-smtp' );
 		}
 		public function getOwnerName() {
 			return '';
@@ -298,7 +298,7 @@ if ( ! class_exists( 'PostmanNonOAuthScribe' ) ) {
 			return '';
 		}
 		public function getRequestPermissionLinkText() {
-			return __( 'Grant OAuth 2.0 Permission', Postman::TEXT_DOMAIN );
+			return __( 'Grant OAuth 2.0 Permission', 'post-smtp' );
 		}
 	}
 }

--- a/Postman/PostmanInputSanitizer.php
+++ b/Postman/PostmanInputSanitizer.php
@@ -157,7 +157,7 @@ if ( ! class_exists( 'PostmanInputSanitizer' ) ) {
 				if ( $value <= 0 ) {
 					$new_input [ $key ] = PostmanOptions::getInstance()->getMailLoggingMaxEntries();
 					$h = new PostmanMessageHandler();
-					$h->addError( sprintf( '%s %s', __( 'Maximum Log Entries', Postman::TEXT_DOMAIN ), __( 'must be greater than 0', Postman::TEXT_DOMAIN ) ) );
+					$h->addError( sprintf( '%s %s', __( 'Maximum Log Entries', 'post-smtp' ), __( 'must be greater than 0', 'post-smtp' ) ) );
 				} else {
 					$this->logSanitize( $desc, $input [ $key ] );
 					$new_input [ $key ] = $value;

--- a/Postman/PostmanViewController.php
+++ b/Postman/PostmanViewController.php
@@ -55,11 +55,11 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			check_ajax_referer( 'postman', 'security' );
 
 			if ( ! PostmanUtils::lockFileExists() ) {
-				echo __('No lock file found.', Postman::TEXT_DOMAIN );
+				echo __('No lock file found.', 'post-smtp' );
 				die();
 			}
 
-			echo PostmanUtils::deleteLockFile() == true ? __('Success, try to send test email.', Postman::TEXT_DOMAIN ) : __('Failed, try again.', Postman::TEXT_DOMAIN );
+			echo PostmanUtils::deleteLockFile() == true ? __('Success, try to send test email.', 'post-smtp' ) : __('Failed, try again.', 'post-smtp' );
 			die();
 		}
 
@@ -96,8 +96,8 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 		 */
 		public function generateDefaultContent() {
 			// This page will be under "Settings"
-			$pageTitle = sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Post SMTP', Postman::TEXT_DOMAIN ) );
-			$pluginName = __( 'Post SMTP', Postman::TEXT_DOMAIN );
+			$pageTitle = sprintf( __( '%s Setup', 'post-smtp' ), __( 'Post SMTP', 'post-smtp' ) );
+			$pluginName = __( 'Post SMTP', 'post-smtp' );
 			$uniqueId = self::POSTMAN_MENU_SLUG;
 			$pageOptions = array(
 					$this,
@@ -119,7 +119,7 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 		 * Register the Email Test screen
 		 */
 		public function addPurgeDataSubmenu() {
-			$page = add_submenu_page( null, sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Post SMTP', Postman::TEXT_DOMAIN ) ), __( 'Post SMTP', Postman::TEXT_DOMAIN ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanAdminController::MANAGE_OPTIONS_PAGE_SLUG, array(
+			$page = add_submenu_page( null, sprintf( __( '%s Setup', 'post-smtp' ), __( 'Post SMTP', 'post-smtp' ) ), __( 'Post SMTP', 'post-smtp' ), Postman::MANAGE_POSTMAN_CAPABILITY_NAME, PostmanAdminController::MANAGE_OPTIONS_PAGE_SLUG, array(
 					$this,
 					'outputPurgeDataContent',
 			) );
@@ -157,15 +157,15 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			), '1.13.1' );
 
 			wp_localize_script( PostmanViewController::POSTMAN_SCRIPT, 'postman_ajax_msg', array(
-					'bad_response' => __( 'An unexpected error occurred', Postman::TEXT_DOMAIN ),
-					'corrupt_response' => __( 'Unexpected PHP messages corrupted the Ajax response', Postman::TEXT_DOMAIN ),
+					'bad_response' => __( 'An unexpected error occurred', 'post-smtp' ),
+					'corrupt_response' => __( 'Unexpected PHP messages corrupted the Ajax response', 'post-smtp' ),
 			) );
 
 			wp_localize_script( 'jquery_steps_script', 'steps_current_step', 'steps_current_step' );
 			wp_localize_script( 'jquery_steps_script', 'steps_pagination', 'steps_pagination' );
-			wp_localize_script( 'jquery_steps_script', 'steps_finish', _x( 'Finish', 'Press this button to Finish this task', Postman::TEXT_DOMAIN ) );
-			wp_localize_script( 'jquery_steps_script', 'steps_next', _x( 'Next', 'Press this button to go to the next step', Postman::TEXT_DOMAIN ) );
-			wp_localize_script( 'jquery_steps_script', 'steps_previous', _x( 'Previous', 'Press this button to go to the previous step', Postman::TEXT_DOMAIN ) );
+			wp_localize_script( 'jquery_steps_script', 'steps_finish', _x( 'Finish', 'Press this button to Finish this task', 'post-smtp' ) );
+			wp_localize_script( 'jquery_steps_script', 'steps_next', _x( 'Next', 'Press this button to go to the next step', 'post-smtp' ) );
+			wp_localize_script( 'jquery_steps_script', 'steps_previous', _x( 'Previous', 'Press this button to go to the previous step', 'post-smtp' ) );
 			wp_localize_script( 'jquery_steps_script', 'steps_loading', 'steps_loading' );
 		}
 
@@ -177,7 +177,7 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			print '<div class="wrap">';
 			$this->displayTopNavigation();
 			if ( ! PostmanPreRequisitesCheck::isReady() ) {
-				printf( '<p><span style="color:red; padding:2px 0; font-size:1.1em">%s</span></p>', __( 'Postman is unable to run. Email delivery is being handled by WordPress (or another plugin).', Postman::TEXT_DOMAIN ) );
+				printf( '<p><span style="color:red; padding:2px 0; font-size:1.1em">%s</span></p>', __( 'Postman is unable to run. Email delivery is being handled by WordPress (or another plugin).', 'post-smtp' ) );
 			} else {
 				$ready_messsage = PostmanTransportRegistry::getInstance()->getReadyMessage();
 				$statusMessage = $ready_messsage['message'];
@@ -193,27 +193,27 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 				$this->printDeliveryDetails();
 				/* translators: where %d is the number of emails delivered */
 				print '<p style="margin:10px 10px"><span>';
-				printf( _n( 'Postman has delivered <span style="color:green">%d</span> email.', 'Postman has delivered <span style="color:green">%d</span> emails.', PostmanState::getInstance()->getSuccessfulDeliveries(), Postman::TEXT_DOMAIN ), PostmanState::getInstance()->getSuccessfulDeliveries() );
+				printf( _n( 'Postman has delivered <span style="color:green">%d</span> email.', 'Postman has delivered <span style="color:green">%d</span> emails.', PostmanState::getInstance()->getSuccessfulDeliveries(), 'post-smtp' ), PostmanState::getInstance()->getSuccessfulDeliveries() );
 				if ( $this->options->isMailLoggingEnabled() ) {
 					print ' ';
-					printf( __( 'The last %d email attempts are recorded <a href="%s">in the log</a>.', Postman::TEXT_DOMAIN ), PostmanOptions::getInstance()->getMailLoggingMaxEntries(), PostmanUtils::getEmailLogPageUrl() );
+					printf( __( 'The last %d email attempts are recorded <a href="%s">in the log</a>.', 'post-smtp' ), PostmanOptions::getInstance()->getMailLoggingMaxEntries(), PostmanUtils::getEmailLogPageUrl() );
 				}
 				print '</span></p>';
 			}
 			if ( $this->options->isNew() ) {
-				printf( '<h3 style="padding-top:10px">%s</h3>', __( 'Thank-you for choosing Postman!', Postman::TEXT_DOMAIN ) );
+				printf( '<h3 style="padding-top:10px">%s</h3>', __( 'Thank-you for choosing Postman!', 'post-smtp' ) );
 				/* translators: where %s is the URL of the Setup Wizard */
-				printf( '<p><span>%s</span></p>', sprintf( __( 'Let\'s get started! All users are strongly encouraged to <a href="%s">run the Setup Wizard</a>.', Postman::TEXT_DOMAIN ), $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG ) ) );
-				printf( '<p><span>%s</span></p>', sprintf( __( 'Alternately, <a href="%s">manually configure</a> your own settings and/or modify advanced options.', Postman::TEXT_DOMAIN ), $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_SLUG ) ) );
+				printf( '<p><span>%s</span></p>', sprintf( __( 'Let\'s get started! All users are strongly encouraged to <a href="%s">run the Setup Wizard</a>.', 'post-smtp' ), $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG ) ) );
+				printf( '<p><span>%s</span></p>', sprintf( __( 'Alternately, <a href="%s">manually configure</a> your own settings and/or modify advanced options.', 'post-smtp' ), $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_SLUG ) ) );
 			} else {
 				if ( PostmanState::getInstance()->isTimeToReviewPostman() && ! PostmanOptions::getInstance()->isNew() ) {
 					print '</br><hr width="70%"></br>';
 					/* translators: where %s is the URL to the WordPress.org review and ratings page */
-					printf( '%s</span></p>', sprintf( __( 'Please consider <a href="%s">leaving a review</a> to help spread the word! :D', Postman::TEXT_DOMAIN ), 'https://wordpress.org/support/view/plugin-reviews/post-smtp?filter=5' ) );
+					printf( '%s</span></p>', sprintf( __( 'Please consider <a href="%s">leaving a review</a> to help spread the word! :D', 'post-smtp' ), 'https://wordpress.org/support/view/plugin-reviews/post-smtp?filter=5' ) );
 				}
-				printf( '<p><span>%s :-)</span></p>', sprintf( __( 'Postman needs translators! Please take a moment to <a href="%s">translate a few sentences on-line</a>', Postman::TEXT_DOMAIN ), 'https://translate.wordpress.org/projects/wp-plugins/post-smtp/stable' ) );
+				printf( '<p><span>%s :-)</span></p>', sprintf( __( 'Postman needs translators! Please take a moment to <a href="%s">translate a few sentences on-line</a>', 'post-smtp' ), 'https://translate.wordpress.org/projects/wp-plugins/post-smtp/stable' ) );
 			}
-			printf( '<p><span>%s</span></p>', __( '<b style="background-color:yellow">New for v1.7!</style></b> Send mail with the Mandrill or SendGrid APIs.', Postman::TEXT_DOMAIN ) );
+			printf( '<p><span>%s</span></p>', __( '<b style="background-color:yellow">New for v1.7!</style></b> Send mail with the Mandrill or SendGrid APIs.', 'post-smtp' ) );
 		}
 
 		/**
@@ -230,29 +230,29 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 		 * @param string  $slug
 		 */
 		public static function outputChildPageHeader( $title, $slug = '' ) {
-			printf( '<h2>%s</h2>', sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Post SMTP', Postman::TEXT_DOMAIN ) ) );
+			printf( '<h2>%s</h2>', sprintf( __( '%s Setup', 'post-smtp' ), __( 'Post SMTP', 'post-smtp' ) ) );
 			printf( '<div id="postman-main-menu" class="welcome-panel %s">', $slug );
 			print '<div class="welcome-panel-content">';
 			print '<div class="welcome-panel-column-container">';
 			print '<div class="welcome-panel-column welcome-panel-last">';
 			printf( '<h4>%s</h4>', $title );
 			print '</div>';
-			printf( '<p id="back_to_main_menu">%s <a id="back_to_menu_link" href="%s">%s</a></p>', self::BACK_ARROW_SYMBOL, PostmanUtils::getSettingsPageUrl(), _x( 'Back To Main Menu', 'Return to main menu link', Postman::TEXT_DOMAIN ) );
+			printf( '<p id="back_to_main_menu">%s <a id="back_to_menu_link" href="%s">%s</a></p>', self::BACK_ARROW_SYMBOL, PostmanUtils::getSettingsPageUrl(), _x( 'Back To Main Menu', 'Return to main menu link', 'post-smtp' ) );
 			print '</div></div></div>';
 		}
 
 		/**
 		 */
 		public function outputPurgeDataContent() {
-			$importTitle = __( 'Import', Postman::TEXT_DOMAIN );
-			$exportTile = __( 'Export', Postman::TEXT_DOMAIN );
-			$resetTitle = __( 'Reset Plugin', Postman::TEXT_DOMAIN );
+			$importTitle = __( 'Import', 'post-smtp' );
+			$exportTile = __( 'Export', 'post-smtp' );
+			$resetTitle = __( 'Reset Plugin', 'post-smtp' );
 			$options = $this->options;
 			print '<div class="wrap">';
 			PostmanViewController::outputChildPageHeader( sprintf( '%s/%s/%s', $importTitle, $exportTile, $resetTitle ) );
 			print '<section id="export_settings">';
 			printf( '<h3><span>%s<span></h3>', $exportTile );
-			printf( '<p><span>%s</span></p>', __( 'Copy this data into another instance of Postman to duplicate the configuration.', Postman::TEXT_DOMAIN ) );
+			printf( '<p><span>%s</span></p>', __( 'Copy this data into another instance of Postman to duplicate the configuration.', 'post-smtp' ) );
 			$data = '';
 			if ( ! PostmanPreRequisitesCheck::checkZlibEncode() ) {
 				$extraDeleteButtonAttributes = sprintf( 'disabled="true"' );
@@ -271,15 +271,15 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			wp_nonce_field( PostmanAdminController::IMPORT_SETTINGS_SLUG );
 			printf( '<input type="hidden" name="action" value="%s" />', PostmanAdminController::IMPORT_SETTINGS_SLUG );
 			print '<p>';
-			printf( '<span>%s</span>', __( 'Paste data from another instance of Postman here to duplicate the configuration.', Postman::TEXT_DOMAIN ) );
+			printf( '<span>%s</span>', __( 'Paste data from another instance of Postman here to duplicate the configuration.', 'post-smtp' ) );
 			if ( PostmanTransportRegistry::getInstance()->getSelectedTransport()->isOAuthUsed( PostmanOptions::getInstance()->getAuthenticationType() ) ) {
-				$warning = __( 'Warning', Postman::TEXT_DOMAIN );
-				$errorMessage = __( 'Using the same OAuth 2.0 Client ID and Client Secret from this site at the same time as another site will cause failures.', Postman::TEXT_DOMAIN );
+				$warning = __( 'Warning', 'post-smtp' );
+				$errorMessage = __( 'Using the same OAuth 2.0 Client ID and Client Secret from this site at the same time as another site will cause failures.', 'post-smtp' );
 				printf( ' <span><b>%s</b>: %s</span>', $warning, $errorMessage );
 			}
 			print '</p>';
 			printf( '<textarea cols="80" rows="5" name="settings" %s></textarea>', $extraDeleteButtonAttributes );
-			submit_button( __( 'Import', Postman::TEXT_DOMAIN ), 'primary', 'import', true, $extraDeleteButtonAttributes );
+			submit_button( __( 'Import', 'post-smtp' ), 'primary', 'import', true, $extraDeleteButtonAttributes );
 			print '</form>';
 			print '</section>';
 			print '<section id="delete_settings">';
@@ -287,7 +287,7 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			print '<form method="POST" action="' . get_admin_url() . 'admin-post.php">';
 			wp_nonce_field( PostmanAdminController::PURGE_DATA_SLUG );
 			printf( '<input type="hidden" name="action" value="%s" />', PostmanAdminController::PURGE_DATA_SLUG );
-			printf( '<p><span>%s</span></p><p><span>%s</span></p>', __( 'This will purge all of Postman\'s settings, including account credentials and the email log.', Postman::TEXT_DOMAIN ), __( 'Are you sure?', Postman::TEXT_DOMAIN ) );
+			printf( '<p><span>%s</span></p><p><span>%s</span></p>', __( 'This will purge all of Postman\'s settings, including account credentials and the email log.', 'post-smtp' ), __( 'Are you sure?', 'post-smtp' ) );
 			$extraDeleteButtonAttributes = 'style="background-color:red;color:white"';
 			if ( $this->options->isNew() ) {
 				$extraDeleteButtonAttributes .= ' disabled="true"';
@@ -303,7 +303,7 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 		private function displayTopNavigation() {
 			$version = PostmanState::getInstance()->getVersion();
 			$show = get_option('postman_release_version_'. $version );
-			printf( '<h2>%s</h2>', sprintf( __( '%s Setup', Postman::TEXT_DOMAIN ), __( 'Post SMTP', Postman::TEXT_DOMAIN ) ) );
+			printf( '<h2>%s</h2>', sprintf( __( '%s Setup', 'post-smtp' ), __( 'Post SMTP', 'post-smtp' ) ) );
 
 			if ( ! $show ) {
 				echo '
@@ -321,21 +321,21 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			print '<div class="welcome-panel-content">';
 			print '<div class="welcome-panel-column-container">';
 			print '<div class="welcome-panel-column">';
-			printf( '<h4>%s</h4>', __( 'Configuration', Postman::TEXT_DOMAIN ) );
-			printf( '<a class="button button-primary button-hero" href="%s">%s</a>', $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG ), __( 'Start the Wizard', Postman::TEXT_DOMAIN ) );
-			printf( '<p class="">%s <a href="%s" class="configure_manually">%s</a></p>', __( 'or', Postman::TEXT_DOMAIN ), $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_SLUG ), __( 'Show All Settings', Postman::TEXT_DOMAIN ) );
+			printf( '<h4>%s</h4>', __( 'Configuration', 'post-smtp' ) );
+			printf( '<a class="button button-primary button-hero" href="%s">%s</a>', $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG ), __( 'Start the Wizard', 'post-smtp' ) );
+			printf( '<p class="">%s <a href="%s" class="configure_manually">%s</a></p>', __( 'or', 'post-smtp' ), $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_SLUG ), __( 'Show All Settings', 'post-smtp' ) );
 			print '</div>';
 			print '<div class="welcome-panel-column">';
-			printf( '<h4>%s</h4>', _x( 'Actions', 'Main Menu', Postman::TEXT_DOMAIN ) );
+			printf( '<h4>%s</h4>', _x( 'Actions', 'Main Menu', 'post-smtp' ) );
 			print '<ul>';
 
 			// Grant permission with Google
 			PostmanTransportRegistry::getInstance()->getSelectedTransport()->printActionMenuItem();
 
 			if ( PostmanWpMailBinder::getInstance()->isBound() ) {
-				printf( '<li><a href="%s" class="welcome-icon send_test_email">%s</a></li>', $this->getPageUrl( PostmanSendTestEmailController::EMAIL_TEST_SLUG ), __( 'Send a Test Email', Postman::TEXT_DOMAIN ) );
+				printf( '<li><a href="%s" class="welcome-icon send_test_email">%s</a></li>', $this->getPageUrl( PostmanSendTestEmailController::EMAIL_TEST_SLUG ), __( 'Send a Test Email', 'post-smtp' ) );
 			} else {
-				printf( '<li><div class="welcome-icon send_test_email">%s</div></li>', __( 'Send a Test Email', Postman::TEXT_DOMAIN ) );
+				printf( '<li><div class="welcome-icon send_test_email">%s</div></li>', __( 'Send a Test Email', 'post-smtp' ) );
 			}
 
 			// import-export-reset menu item
@@ -344,21 +344,21 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 			} else {
 				$purgeLinkPattern = '<li>%2$s</li>';
 			}
-			$importTitle = __( 'Import', Postman::TEXT_DOMAIN );
-			$exportTile = __( 'Export', Postman::TEXT_DOMAIN );
-			$resetTitle = __( 'Reset Plugin', Postman::TEXT_DOMAIN );
+			$importTitle = __( 'Import', 'post-smtp' );
+			$exportTile = __( 'Export', 'post-smtp' );
+			$resetTitle = __( 'Reset Plugin', 'post-smtp' );
 			$importExportReset = sprintf( '%s/%s/%s', $importTitle, $exportTile, $resetTitle );
 			printf( $purgeLinkPattern, $this->getPageUrl( PostmanAdminController::MANAGE_OPTIONS_PAGE_SLUG ), sprintf( '%s', $importExportReset ) );
 			print '</ul>';
 			print '</div>';
 			print '<div class="welcome-panel-column welcome-panel-last">';
-			printf( '<h4>%s</h4>', _x( 'Troubleshooting', 'Main Menu', Postman::TEXT_DOMAIN ) );
+			printf( '<h4>%s</h4>', _x( 'Troubleshooting', 'Main Menu', 'post-smtp' ) );
 			print '<ul>';
-			printf( '<li><a href="%s" class="welcome-icon run-port-test">%s</a></li>', $this->getPageUrl( PostmanConnectivityTestController::PORT_TEST_SLUG ), __( 'Connectivity Test', Postman::TEXT_DOMAIN ) );
-			printf( '<li><a href="%s" class="welcome-icon run-port-test">%s</a></li>', $this->getPageUrl( PostmanDiagnosticTestController::DIAGNOSTICS_SLUG ), __( 'Diagnostic Test', Postman::TEXT_DOMAIN ) );
-			printf( '<li><a href="%s" data-security="%s" class="welcome-icon release-lock-file">%s</a></li>', '#', wp_create_nonce( "postman" ), __( 'Release Lock File Error', Postman::TEXT_DOMAIN ) );
-			printf( '<li><a href="https://postmansmtp.com/forums/" class="welcome-icon postman_support">%s</a></li>', __( 'Online Support', Postman::TEXT_DOMAIN ) );
-			printf( '<li><img class="align-middle" src="' . plugins_url( 'style/images/new.gif', dirname( __DIR__ ) . '/postman-smtp.php' ) . '"><a target="blank" class="align-middle" href="https://postmansmtp.com/category/guides/" class="welcome-icon postman_guides">%s</a></li>', __( 'Guides', Postman::TEXT_DOMAIN ) );
+			printf( '<li><a href="%s" class="welcome-icon run-port-test">%s</a></li>', $this->getPageUrl( PostmanConnectivityTestController::PORT_TEST_SLUG ), __( 'Connectivity Test', 'post-smtp' ) );
+			printf( '<li><a href="%s" class="welcome-icon run-port-test">%s</a></li>', $this->getPageUrl( PostmanDiagnosticTestController::DIAGNOSTICS_SLUG ), __( 'Diagnostic Test', 'post-smtp' ) );
+			printf( '<li><a href="%s" data-security="%s" class="welcome-icon release-lock-file">%s</a></li>', '#', wp_create_nonce( "postman" ), __( 'Release Lock File Error', 'post-smtp' ) );
+			printf( '<li><a href="https://postmansmtp.com/forums/" class="welcome-icon postman_support">%s</a></li>', __( 'Online Support', 'post-smtp' ) );
+			printf( '<li><img class="align-middle" src="' . plugins_url( 'style/images/new.gif', dirname( __DIR__ ) . '/postman-smtp.php' ) . '"><a target="blank" class="align-middle" href="https://postmansmtp.com/category/guides/" class="welcome-icon postman_guides">%s</a></li>', __( 'Guides', 'post-smtp' ) );
 			print '</ul></div></div></div></div>';
 		}
 	}

--- a/Postman/notifications/PostmanMailNotify.php
+++ b/Postman/notifications/PostmanMailNotify.php
@@ -7,6 +7,6 @@ class PostmanMailNotify implements Postman_Notify {
         $to_email = apply_filters( 'post_smtp_notify_email',get_bloginfo( 'admin_email' ) );
         $domain = get_bloginfo( 'url' );
 
-        mail( $to_email, "{$domain}: " .  __( 'Post SMTP email error', Postman::TEXT_DOMAIN ), $message , '', "-f{$to_email}" );
+        mail( $to_email, "{$domain}: " .  __( 'Post SMTP email error', 'post-smtp' ), $message , '', "-f{$to_email}" );
     }
 }


### PR DESCRIPTION
This should be removed as it breaks compatibility with translate.wordpress.org