### PR TITLE
Undefined Index (spinning wheel but mail was sent)

### DIFF
--- a/Postman/Postman-Mail/PostmanContactForm7.php
+++ b/Postman/Postman-Mail/PostmanContactForm7.php
@@ -13,7 +13,7 @@ class Postsmtp_ContactForm7 {
     }
 
     public function change_rest_response( $response ) {
-        if ( $response['status'] == 'mail_failed' ) {
+        if ( array_key_exists('status', $response) && $response['status'] == 'mail_failed' ) {
             $message = $this->result_error ['exception']->getMessage();
 
             if ( ! $message || $message == '' ) {


### PR DESCRIPTION
I ran into an issue with this plugin in combination with Contact Form 7. On submitting the form it would send the email successfully (using Google oAuth) but it would return an undefined index notice in the XHR response. This would cause the spinning wheel to run indefinitely without returning a success response to the front-end even though the mail was sent. So I added an additional key check before it goes and check its value.