### PR TITLE
Fix multipart/alternative boundary delimiter leak in createBodyParts (#129)

### DIFF
--- a/Postman/Postman-Mail/PostmanMessage.php
+++ b/Postman/Postman-Mail/PostmanMessage.php
@@ -119,8 +119,33 @@ if ( ! class_exists( 'PostmanMessage' ) ) {
 				$textBody = '';
 				$htmlBody = '';
 				$mode = '';
+
+				// Per RFC 2046 §5.1.1, MIME boundary delimiter lines are
+				// `--<boundary>` (between parts) and `--<boundary>--`
+				// (closing). Without recognising them, the loop below
+				// captures these markers into the body of whichever part
+				// is currently being read, and the recipient's email
+				// client renders them as visible text.
+				$delimiter         = ! empty( $this->boundary ) ? '--' . $this->boundary : '';
+				$closing_delimiter = ! empty( $this->boundary ) ? '--' . $this->boundary . '--' : '';
+
 				foreach ( $arr as $s ) {
 					$this->logger->trace( 'mode: ' . $mode . ' bodyline: ' . $s );
+
+					// Strip a trailing CR that explode() on PHP_EOL ('\n'
+					// on *nix) leaves behind when the body uses CRLF
+					// terminators, so the boundary comparison is exact.
+					$line = rtrim( $s, "\r" );
+
+					if ( '' !== $delimiter && ( $line === $delimiter || $line === $closing_delimiter ) ) {
+						// End of the current part. Reset to neutral mode
+						// so the next Content-Type line picks up the
+						// next part (or, for the closing delimiter, so
+						// trailing epilogue is ignored).
+						$mode = '';
+						continue;
+					}
+
 					if ( substr( $s, 0, 25 ) === 'Content-Type: text/plain;' ) {
 						$mode = 'foundText';
 					} else if ( substr( $s, 0, 24 ) === 'Content-Type: text/html;' ) {


### PR DESCRIPTION
Fixes #129.

## What

`PostmanMessage::createBodyParts()` re-parses pre-formed `multipart/alternative` bodies passed in via `wp_mail()` to populate `bodyTextPart` and `bodyHtmlPart`. The state machine recognises the per-part `Content-Type: text/plain;` and `Content-Type: text/html;` headers, but it does not recognise MIME boundary delimiter lines. As a result every `--<boundary>` (between parts) and the trailing `--<boundary>--` (closing) is captured into whichever part is currently being read: the closing delimiter lands at the tail of the HTML part and is rendered by recipient email clients as visible text.

This affects any plugin that passes a multipart body to `wp_mail()`. WordPress 6.9.0 made multipart sending via `wp_mail()` viable for plugins, so the bug surfaces wherever a plugin takes that route. cforms2 hit it (referenced in #129) and Google Site Kit hit it on the email-reporting feature, which is what motivated this PR.

## How

Recognise boundary delimiter lines explicitly inside the parser loop:

- Compute `$delimiter = '--' . $this->boundary` and `$closing_delimiter = '--' . $this->boundary . '--'` once before the loop, from the boundary that `addHeaders()` already captures from the `Content-Type` header.
- Inside the loop, `rtrim( $s, "\r" )` once so that `explode(PHP_EOL, $body)` on *nix hosts (where `PHP_EOL` is `\n`) does not leave a trailing CR that prevents an exact match against the delimiter.
- If the trimmed line equals either delimiter, reset `$mode = ''` and `continue`. The next `Content-Type:` line picks up the next part as before. Any trailing epilogue after the closing delimiter is discarded.

The fix is additive: the existing detection logic for `Content-Type: text/plain;` / `Content-Type: text/html;` is unchanged, and the existing reading-mode behaviour is unchanged for non-delimiter lines.

## Before / After

Verified against a Site Kit-shaped body (CRLF endings, both parts present, RFC 2046-compliant boundary):

```
--BOUNDARY
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Plain text content
--BOUNDARY
Content-Type: text/html; charset=UTF-8
Content-Transfer-Encoding: 8bit

<html>...</html>
--BOUNDARY--
```

**Before this PR:**
- `bodyTextPart` = `Plain text content` + `--BOUNDARY` (intermediate delimiter leaked)
- `bodyHtmlPart` = `<html>...</html>` + `--BOUNDARY--` (closing delimiter leaked, visible to recipient)

**After this PR:**
- `bodyTextPart` = `Plain text content`
- `bodyHtmlPart` = `<html>...</html>`

## Scope

This PR is scoped to issue #129 (boundary delimiter stripping). I noticed during investigation that the parser also concatenates lines via `$textBody .= $s` without re-inserting newlines, so a multi-line plain-text part collapses to a single line on the recipient side. That is a separate bug from #129 and not addressed here. Happy to file it as a follow-up issue (or fold into a follow-up PR) if useful.

## Testing notes

The repository does not currently have a PHPUnit suite that covers `PostmanMessage`, so I verified the change with a focused harness that runs the exact patched parser logic against the multipart body shape described above and asserts neither delimiter appears in the captured parts. Happy to add a unit test if you would like to start a `tests/` directory for this class. Just let me know the convention you prefer.

## Risk

Low. The change is contained to the `multipart/alternative` branch of `createBodyParts()`. The new branch only fires on lines that exactly equal the parsed `$this->boundary` value (after rtrim of a single trailing CR), so legitimate body content that happens to start with `--` is unaffected unless it coincidentally equals the message-specific boundary, which by RFC 2046 §5.1.1 is required to be unique and unguessable per message.
