### PR TITLE
fix(oauth): clear transient flag on cancel to prevent 302 loop

### DIFF
--- a/Postman/Postman-Email-Log/PostmanEmailLogMigration.php
+++ b/Postman/Postman-Email-Log/PostmanEmailLogMigration.php
@@ -48,20 +48,22 @@ class PostmanEmailLogsMigration {
 
         }
 
-        if( isset( $_GET['action'] ) && $_GET['action'] == 'ps-migrate-logs' ) {
+        $is_admin_request = is_admin() && current_user_can( 'manage_options' );
+
+        if( $is_admin_request && isset( $_GET['action'] ) && $_GET['action'] == 'ps-migrate-logs' ) {
 
             $this->update_database();
 
         }
 
-        if( isset( $_GET['action'] ) && $_GET['action'] == 'ps-delete-old-logs' ) {
+        if( $is_admin_request && isset( $_GET['action'] ) && $_GET['action'] == 'ps-delete-old-logs' ) {
 
             $this->log( 'Info: Delete old logs' );
 
             $this->trash_all_old_logs();
 
         }
-        
+
         //Add Hook of Migration, Schedule Migration
         if( $this->migrating && ( isset( $_GET['page'] ) && $_GET['page'] == 'postman_email_log' ) ) {
 
@@ -70,28 +72,28 @@ class PostmanEmailLogsMigration {
         }
 
         //Switch back to old system
-        if( isset( $_GET['action'] ) && $_GET['action'] == 'ps-switch-back' ) {
+        if( $is_admin_request && isset( $_GET['action'] ) && $_GET['action'] == 'ps-switch-back' ) {
 
             $this->switch_back();
 
         }
 
         //Switch to new system
-        if( isset( $_GET['action'] ) && $_GET['action'] == 'ps-switch-to-new' ) {
+        if( $is_admin_request && isset( $_GET['action'] ) && $_GET['action'] == 'ps-switch-to-new' ) {
 
             $this->switch_to_new();
 
         }
 
         //Revert Migration
-        if( isset( $_GET['action'] ) && $_GET['action'] == 'ps-revert-migration' ) {
+        if( $is_admin_request && isset( $_GET['action'] ) && $_GET['action'] == 'ps-revert-migration' ) {
 
             $this->revert_migration();
 
         }
 
         //Skip Migration
-        if( isset( $_GET['action'] ) && $_GET['action'] == 'ps-skip-migration' ) {
+        if( $is_admin_request && isset( $_GET['action'] ) && $_GET['action'] == 'ps-skip-migration' ) {
 
             $this->skip_migration();
 

--- a/Postman/PostmanAdminController.php
+++ b/Postman/PostmanAdminController.php
@@ -127,6 +127,9 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 				if ( isset( $_GET['error'] ) && $_GET['error'] === 'access_denied' ) {
 					$this->logger->debug( 'User denied Gmail OAuth access' );
 
+					// Clear the OAuth in-progress flag so subsequent requests don't bounce through this branch.
+					$session->unsetOauthInProgress();
+
 					$message = __( 'Gmail authorization was cancelled by the user.', 'post-smtp' );
 					$this->messageHandler->addError( $message );
 
@@ -142,6 +145,8 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 
 					// queue the function that processes the incoming grant code
 					$this->registerInitFunction( 'handleAuthorizationGrant' );
+					// Clear the OAuth in-progress flag so subsequent requests don't re-enter this branch.
+					$session->unsetOauthInProgress();
 					return;
 				}
 			}


### PR DESCRIPTION
## Summary

Fix 302 redirect loop on frontend pages after OAuth cancellation in Gmail API setup. The `oauth_in_progress` transient (3-min TTL) stays set after user cancels the OAuth prompt, causing subsequent requests with `?error=access_denied` in URL to re-enter the redirect path. Also hardens EmailLogMigration constructor against frontend-triggered redirects.

Fixes #133

## Changes

### Postman/PostmanAdminController.php
**Before:**
```php
if ( isset( $_GET[\x27error\x27] ) && $_GET[\x27error\x27] === \x27access_denied\x27 ) {
    $this->logger->debug( \x27User denied Gmail OAuth access\x27 );
    $message = __( \x27Gmail authorization was cancelled by the user.\x27, \x27post-smtp\x27 );
    $this->messageHandler->addError( $message );
    $redirect_uri = admin_url( "admin.php?page=postman/configuration_wizard&socket=gmail_api&step=2&msg=" . urlencode( $message ) . "&success=0" );
    wp_redirect( $redirect_uri );
    exit;
}
```
**After:**
```php
if ( isset( $_GET[\x27error\x27] ) && $_GET[\x27error\x27] === \x27access_denied\x27 ) {
    $this->logger->debug( \x27User denied Gmail OAuth access\x27 );
    $session->unsetOauthInProgress();
    $message = __( \x27Gmail authorization was cancelled by the user.\x27, \x27post-smtp\x27 );
    $this->messageHandler->addError( $message );
    $redirect_uri = admin_url( "admin.php?page=postman/configuration_wizard&socket=gmail_api&step=2&msg=" . urlencode( $message ) . "&success=0" );
    wp_redirect( $redirect_uri );
    exit;
}
```
**Why:** Without clearing `oauth_in_progress` transient before redirect, any request within the 3-min window that carries `?error=access_denied` (bookmarked, cached, or injected by a security/CSP plugin) re-enters the redirect branch, creating a loop.

Same fix applied to the success branch (`isset( $_GET[\x27code\x27] )`) for consistency.

### Postman/Postman-Email-Log/PostmanEmailLogMigration.php
**Before:**
```php
if( isset( $_GET[\x27action\x27] ) && $_GET[\x27action\x27] == \x27ps-migrate-logs\x27 ) {
```
**After:**
```php
$is_admin_request = is_admin() && current_user_can( \x27manage_options\x27 );
if( $is_admin_request && isset( $_GET[\x27action\x27] ) && $_GET[\x27action\x27] == \x27ps-migrate-logs\x27 ) {
```
**Why:** EmailLogMigration constructor runs on every page load (admin + frontend). The `$_GET[\x27action\x27]` dispatch fires before nonce checks, so a cached frontend URL with an action parameter could trigger `wp_redirect`. Guarding with `is_admin() + current_user_can()` prevents this.

## Testing

**Test 1: No regression on OAuth flow (happy path)**
1. Install plugin, go to Gmail API setup
2. Complete OAuth authorization
3. Verify token saved, redirects to wizard step 2 with success message

**Test 2: Cancel OAuth no longer causes redirect loop**
1. Start Gmail API setup, click "Grant Permission"
2. Deny/cancel the Google OAuth prompt
3. Within 3 minutes, load any frontend page with `?error=access_denied` in URL
4. Result: page loads normally, no redirect

**Test 3: Email log migration still works in admin**
1. Go to Email Log page, run migration
2. Result: migration completes without error