### PR TITLE
fix(diagnostics): declare $cleanDiagnostics property

### DIFF
--- a/Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php
+++ b/Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php
@@ -156,6 +156,7 @@ class PostmanDiagnosticTestController {
  */
 class PostmanGetDiagnosticsViaAjax {
 	private $diagnostics;
+	private $cleanDiagnostics;
 	private $options;
 	private $authorizationToken;
 	/**


### PR DESCRIPTION
## Summary
Fixes the PHP 8.3 deprecation notice emitted on every diagnostic AJAX request: `Deprecated: Creation of dynamic property PostmanGetDiagnosticsViaAjax::$cleanDiagnostics is deprecated`. The class assigned to the property in its constructor without declaring it, so PHP 8.3 flags it and PHP 8.4 would escalate it to a fatal error.
\nFixes #126

## Changes
### `Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php`
**Before:**
```php
class PostmanGetDiagnosticsViaAjax {
    private $diagnostics;
    private $options;
    private $authorizationToken;
```
**After:**
```php
class PostmanGetDiagnosticsViaAjax {
    private $diagnostics;
    private $cleanDiagnostics;
    private $options;
    private $authorizationToken;
```
**Why:** The constructor at line 170 assigns `$this->cleanDiagnostics = '';` without a matching declaration, so every call creates the property dynamically. Adding the declaration next to its siblings silences the deprecation without changing behaviour. All existing usage at lines 170, 176, and 348 still works.

## Testing
**PHP 8.3 + WP_DEBUG**
1. Install Post SMTP 3.3.0 with PHP 8.3, WP 6.8.1, and WP_DEBUG=true WP_DEBUG_LOG=true.
2. Before applying the fix: trigger the diagnostic test from `wp-admin` and confirm `wp-content/debug.log` contains the "Creation of dynamic property" deprecation line.
3. Apply the fix and repeat step 2.
4. Result: the deprecation entry no longer appears, and the `post_smtp_clean_diagnostic_report_data` option is still populated with the diagnostic text as before.
\nTested manually against a WordPress 6.8.1 install on PHP 8.3.