### PR TITLE
fix(installer): guard addCapability against missing administrator role

### DIFF
--- a/Postman/PostmanInstaller.php
+++ b/Postman/PostmanInstaller.php
@@ -150,6 +150,12 @@ class PostmanInstaller {
 		// NB: This setting is saved to the database, so it might be better to run this on theme/plugin activation
 		// add the custom capability to the administrator role
 		$role = get_role( Postman::ADMINISTRATOR_ROLE_NAME );
+		if ( ! $role ) {
+			if ( $this->logger->isDebug() ) {
+				$this->logger->debug( sprintf( 'Skipping capability change: %s role not found', Postman::ADMINISTRATOR_ROLE_NAME ) );
+			}
+			return;
+		}
 		$role->add_cap( Postman::MANAGE_POSTMAN_CAPABILITY_NAME );
 		$role->add_cap( Postman::MANAGE_POSTMAN_CAPABILITY_LOGS );
 	}
@@ -165,6 +171,12 @@ class PostmanInstaller {
 		// NB: This setting is saved to the database, so it might be better to run this on theme/plugin activation
 		// remove the custom capability from the administrator role
 		$role = get_role( Postman::ADMINISTRATOR_ROLE_NAME );
+		if ( ! $role ) {
+			if ( $this->logger->isDebug() ) {
+				$this->logger->debug( sprintf( 'Skipping capability change: %s role not found', Postman::ADMINISTRATOR_ROLE_NAME ) );
+			}
+			return;
+		}
 		$role->remove_cap( Postman::MANAGE_POSTMAN_CAPABILITY_NAME );
         $role->remove_cap( Postman::MANAGE_POSTMAN_CAPABILITY_LOGS );
 	}


### PR DESCRIPTION
## Summary
The plugin crashed on activation and deactivation when the `administrator` role is missing (e.g. a multisite install where it was removed). `PostmanInstaller::addCapability()` and `PostmanInstaller::removeCapability()` called `add_cap()` / `remove_cap()` on the direct return of `get_role()`, which returns `null` when the role does not exist. Both methods now early-return with a debug log entry when the role is absent.

Fixes #123

## Changes
### Postman/PostmanInstaller.php
**Before:**
```php
$role = get_role( Postman::ADMINISTRATOR_ROLE_NAME );
$role->add_cap( Postman::MANAGE_POSTMAN_CAPABILITY_NAME );
$role->add_cap( Postman::MANAGE_POSTMAN_CAPABILITY_LOGS );
```
**After:**
```php
$role = get_role( Postman::ADMINISTRATOR_ROLE_NAME );
if ( ! $role ) {
    if ( $this->logger->isDebug() ) {
        $this->logger->debug( sprintf( 'Skipping capability change: %s role not found', Postman::ADMINISTRATOR_ROLE_NAME ) );
    }
    return;
}
$role->add_cap( Postman::MANAGE_POSTMAN_CAPABILITY_NAME );
$role->add_cap( Postman::MANAGE_POSTMAN_CAPABILITY_LOGS );
```
**Why:** `get_role()` returns `null` (not a WP_Error, not a Role object with add_cap stubbed) when the role is missing. Guard inside the method handles activate and deactivate paths in one place.

Same guard added to `removeCapability()$ (line ~167) for the deactivation flow.

## Testing
**Test 1: Normal activation (single-site)**
1. Fresh WP install with default roles (administrator exists).
2. Activate Post SMTP from Plugins screen.
3. Deactivate, then reactivate.

Result: no fatal; `manage_postman_smtp` and `manage_postman_logs` are present on `administrator` role.

**Test 2: Activation with administrator role removed**
1. Add a small mu-plugin: `remove_role( 'administrator' );`
2. Deactivate Post SMTP, then reactivate.

Result before fix: fatal "Call to a member function add_cap() on null" in PostmanInstaller.php.
Result after fix: no fatal. With `WP_DEBUG_LOG` enabled, `Skipping capability change: administrator role not found` appears in the debug log.

**Test 3: Deactivation with administrator role removed**
1. Same mu-plugin environment as Test 2.

Result before fix: fatal in `removeCapability()$.
Result after fix: no fatal; same skip log entry.