### PR TITLE
fix(email-log): drop redundant isset() before !empty() on status filter

### DIFF
--- a/Postman/Postman-Email-Log/PostmanEmailQueryLog.php
+++ b/Postman/Postman-Email-Log/PostmanEmailQueryLog.php
@@ -143,7 +143,7 @@ class PostmanEmailQueryLog {
 
         // Status Filter
         $clause_for_status = '';
-        if( isset( $args['status'] ) && !empty( $args['status'] ) ) {
+        if( !empty( $args['status'] ) ) {
 
             $clause_for_status = strpos( $this->query, 'WHERE' ) !== FALSE ? ' AND' : ' WHERE';
             


### PR DESCRIPTION
## Summary
Removes redundant `isset()` check before `!empty()` on the email log status filter. PHP `!empty()` already returns false for undefined array keys, so the outer `isset()` was duplicating that check.

Fixes #116

## Changes
### Postman/Postman-Email-Log/PostmanEmailQueryLog.php

**Before:**
```php
if( isset( $args['status'] ) && !empty( $args['status'] ) ) {
```

**After:**
```php
if( !empty( $args['status'] ) ) {
```

**Why:** `!empty()` returns false when the key is unset or the value is falsy (`null`, `''`, `0`, etc.). The companion `isset()` was redundant.

## Testing
1. Open WP admin → Post SMTP → Email Log.
2. Send test email, mark one as failed.
3. Filter by status=failed, status=success, status=empty.
4. Query runs, filter applied correctly. No PHP warning on undefined key.
5. `php -l` on the file: clean.