### PR TITLE
fix(wizard): hoist $urls array out of transport loop

### DIFF
--- a/Postman/Wizard/NewWizard.php
+++ b/Postman/Wizard/NewWizard.php
@@ -176,29 +176,29 @@ class Post_SMTP_New_Wizard {
 
                                         $row  = 0;
 
-                                        $transports = array_merge( array_flip( $this->socket_sequence ), $transports );
-										
-                                        foreach( $transports as $key => $transport ) {
+                                        $urls = array(
+                                            'default'           =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/smtp.png',
+                                            'smtp'              =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/smtp.png',
+                                            'gmail_api'         =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/gmail.png',
+                                            'mandrill_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mandrill.png',
+                                            'sendgrid_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/sendgrid.png',
+                                            'mailersend_api'    =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mailersend.png',
+                                            'mailgun_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mailgun.png',
+                                            'sendinblue_api'    =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/brevo.png',
+                                            'postmark_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/postmark.png',
+                                            'sparkpost_api'     =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/sparkpost.png',
+                                            'mailjet_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mailjet.png',
+                                            'sendpulse_api'     =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/sendpulse.png',
+                                            'smtp2go_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/smtp2go.png',
+                                            'office365_api'     =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/ms365.png',
+                                            'elasticemail_api'  =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/elasticemail.png',
+                                            'aws_ses_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/amazon.png',
+                                            'zohomail_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/zoho.png'
+                                        );
 
-                                            $urls = array(
-                                                'default'           =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/smtp.png',
-                                                'smtp'              =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/smtp.png',
-                                                'gmail_api'         =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/gmail.png',
-                                                'mandrill_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mandrill.png',
-                                                'sendgrid_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/sendgrid.png',
-                                                'mailersend_api'    =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mailersend.png',
-                                                'mailgun_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mailgun.png',
-                                                'sendinblue_api'    =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/brevo.png',
-                                                'postmark_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/postmark.png',
-                                                'sparkpost_api'     =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/sparkpost.png',
-                                                'mailjet_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/mailjet.png',
-                                                'sendpulse_api'     =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/sendpulse.png',
-                                                'smtp2go_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/smtp2go.png',
-                                                'office365_api'     =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/ms365.png',
-                                                'elasticemail_api'  =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/elasticemail.png',
-                                                'aws_ses_api'       =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/amazon.png',
-                                                'zohomail_api'      =>  POST_SMTP_URL . '/Postman/Wizard/assets/images/zoho.png'
-                                            );
+                                        $transports = array_merge( array_flip( $this->socket_sequence ), $transports );
+
+                                        foreach( $transports as $key => $transport ) {
 
                                             $url = '';
                                             $checked = '';


### PR DESCRIPTION
## Summary

The `$urls` lookup table in NewWizard.php was redeclared inside a foreach over transports even though its values never change between iterations. Moved the array definition above the loop so it is built once instead of on every page render of the setup wizard.

Fixes #112

## Changes

### Postman/Wizard/NewWizard.php

Moved the `$urls` array definition from inside the `foreach` body to before it.

## Testing

1. Activate Post SMTP and open `/wp-admin/admin.php?page=postman/configuration_wizard`
2. Inspect each mailer tile in the transport grid
3. Result: each tile still shows the correct logo image. No visual diff.
