### PR TITLE
fix(mandrill): use SECURITY_TYPE_NONE instead of missing PROTOCOL constant

### DIFF
--- a/Postman/Postman-Mail/PostmanMandrillTransport.php
+++ b/Postman/Postman-Mail/PostmanMandrillTransport.php
@@ -85,7 +85,7 @@ class PostmanMandrillTransport extends PostmanAbstractModuleTransport implements
 	 * @return string
 	 */
 	public function getSecurityType() {
-		return self::PROTOCOL;
+		return PostmanOptions::SECURITY_TYPE_NONE;
 	}
 	/**
 	 * v0.2.1


### PR DESCRIPTION
## Summary

PostmanMandrillTransport::getSecurityType() referenced self::PROTOCOL but the class never declared that constant. PHP would throw Error on PHP 8+ and a warning on PHP 7. Any path that asks Mandrill to describe itself — wizard summary screen, transport registry loading, getDeliveryDetails/getPublicTransportUri — would trigger it.

Return PostmanOptions::SECURITY_TYPE_NONE instead, matching PostmanDefaultModuleTransport::getSecurityType(). Mandrill is REST-only via PostmanMandrillMailEngine so the Zend transport factory that branches on SECURITY_TYPE_NONE never applies, but the display layer (getDeliveryDetails is overridden for Mandrill, getPublicTransportUri is only in Zend abstract which Mandrill doesnt extend) handles it correctly.

Fixes #113

## Changes

### Postman/Postman-Mail/PostmanMandrillTransport.php
**Before:** `return self::PROTOCOL;`
**After:** `return PostmanOptions::SECURITY_TYPE_NONE;`
**Why:** PROTOCOL constant was never defined on the class. SECURITY_TYPE_NONE is the same value used by PostmanDefaultModuleTransport and all callers handle it correctly.

## Testing
1. Install build on a WordPress site
2. Pick Mandrill as the transport in Setup Wizard
3. Wizard summary renders without `Undefined constant` errors
4. No errors in wp-content/debug.log with WP_DEBUG_LOG enabled
5. Test email sends successfully (REST path unaffected)