### PR TITLE
fix(zend-mail): drop unused name argument to addBcc method

### DIFF
--- a/Postman/Postman-Mail/PostmanZendMailEngine.php
+++ b/Postman/Postman-Mail/PostmanZendMailEngine.php
@@ -140,7 +140,7 @@ if ( ! class_exists( 'PostmanZendMailEngine' ) ) {
 			// add the to recipients
 			foreach ( ( array ) $message->getBccRecipients() as $recipient ) {
 				$recipient->log( $this->logger, 'Bcc' );
-				$mail->addBcc( $recipient->getEmail(), $recipient->getName() );
+				$mail->addBcc( $recipient->getEmail() );
 			}
 
 			// add the reply-to


### PR DESCRIPTION
## Summary

`PostmanZendMailEngine` passes `$recipient->getName()` as a second argument to `Postman_Zend_Mail::addBcc()`, but the vendor method signature only accepts `$email`. PHP 8 raises warnings for excess non-variadic arguments.

Fixes #104

## Changes

### Postman/Postman-Mail/PostmanZendMailEngine.php

**Before:**
```php
$mail->addBcc( $recipient->getEmail(), $recipient->getName() );
```

**After:**
```php
$mail->addBcc( $recipient->getEmail() );
```

**Why:** The Zend vendor `addBcc()` accepts only `$email` and internally passes `` for the name when calling `_addRecipientAndHeader`. The recipient name was already discarded in practice. Removing the second arg eliminate the PHP 8 warning without changing behavior.

## Testing

**Test 1: Syntax check**
1. Run `php -l Postman/Postman-Mail/PostmanZendMailEngine.php`
Result: No syntax errors detected.

**Test 2: PHP 8 warning regression (WP + PHP 8.1+)**
1. Configure a transport in Post SMTP settings
2. Send a test email with Bcc recipients populated
3. Check `WP_DEBUG_LOG` for any `addBcc` related warnings
Result: No warnings logged.

**Test 3: Bcc delivery**
1. Send a test email with Bcc recipients
2. Verify the email is delivered to Bcc recipients
Result: Delivery works (same behavior as PHP 7).

**Test 4: Cc regression check**
1. Send a test email with Cc recipients
2. Verify Cc display names appear in headers
Result: Cc loop unchanged, names render correctly.