### PR TITLE
fix(query-log): remove unnecessary empty string concatenation

### DIFF
--- a/Postman/Postman-Email-Log/PostmanEmailQueryLog.php
+++ b/Postman/Postman-Email-Log/PostmanEmailQueryLog.php
@@ -157,11 +157,6 @@ class PostmanEmailQueryLog {
                 $this->query .= "{$clause_for_status} `success` != 1 ";
     
             }
-            else {
-    
-                $this->query .= '';
-    
-            }
 
         }
 		


### PR DESCRIPTION
## Summary

Removed a no-op else branch that appended an empty string to the query (`\->query .= '';`). The operation had no effect on the SQL query.

Fixes #101

## Changes

### Postman/Postman-Email-Log/PostmanEmailQueryLog.php

**Before:**
```php
else {

    $this->query .= '';

}
```

**After:**
Removed the empty else block entirely (5 lines deleted).

## Testing

1. Open Email Log in WP Admin.
2. Filter by status: All, Success, Failed.
3. Result: query behaves same as before — empty branch was dead code.

## Screenshots

No UI changes.