### PR TITLE
fix: replace deprecated methods (issue #103)

### DIFF
--- a/Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php
+++ b/Postman/Postman-Diagnostic-Test/PostmanDiagnosticTestController.php
@@ -320,7 +320,7 @@ class PostmanGetDiagnosticsViaAjax {
 			$this->addToDiagnostics( 'Postman Sender Domain (Envelope|Message)', ($hostname = substr( strrchr( $this->options->getEnvelopeSender(), '@' ), 1 )) . ' | ' . ($hostname = substr( strrchr( $this->options->getMessageSenderEmail(), '@' ), 1 )) );
 		}
 		}
-		$this->addToDiagnostics( 'Postman Prevent Message Sender Override (Email|Name)', ($this->options->isSenderEmailOverridePrevented() ? 'Yes' : 'No') . ' | ' . ($this->options->isSenderNameOverridePrevented() ? 'Yes' : 'No') );
+		$this->addToDiagnostics( 'Postman Prevent Message Sender Override (Email|Name)', ($this->options->isPluginSenderEmailEnforced() ? 'Yes' : 'No') . ' | ' . ($this->options->isPluginSenderNameEnforced() ? 'Yes' : 'No') );
 		{
 			// status of the active transport
 			$transport = $transportRegistry->getActiveTransport();

--- a/Postman/Postman-Mail/PostmanMessage.php
+++ b/Postman/Postman-Mail/PostmanMessage.php
@@ -228,7 +228,7 @@ if ( ! class_exists( 'PostmanMessage' ) ) {
 			// Postman has it's own 'user override' filter
 			$options = PostmanOptions::getInstance();
 			$forcedEmailAddress = $options->getMessageSenderEmail();
-			if ( $options->isSenderEmailOverridePrevented() && $this->getFromAddress()->getEmail() !== $forcedEmailAddress ) {
+			if ( $options->isPluginSenderEmailEnforced() && $this->getFromAddress()->getEmail() !== $forcedEmailAddress ) {
 				$this->logger->debug( sprintf( 'Forced From email address: before=%s after=%s', $this->getFromAddress()->getEmail(), $forcedEmailAddress ) );
 				$this->getFromAddress()->setEmail( $forcedEmailAddress );
 			}
@@ -240,7 +240,7 @@ if ( ! class_exists( 'PostmanMessage' ) ) {
 			}
 
 			$forcedEmailName = $options->getMessageSenderName();
-			if ( $options->isSenderNameOverridePrevented() && $this->getFromAddress()->getName() !== $forcedEmailName ) {
+			if ( $options->isPluginSenderNameEnforced() && $this->getFromAddress()->getName() !== $forcedEmailName ) {
 				$this->logger->debug( sprintf( 'Forced From email name: before=%s after=%s', $this->getFromAddress()->getName(), $forcedEmailName ) );
 				$this->getFromAddress()->setName( $forcedEmailName );
 			}

--- a/Postman/Postman-Mail/PostmanTransportRegistry.php
+++ b/Postman/Postman-Mail/PostmanTransportRegistry.php
@@ -236,7 +236,7 @@ class PostmanTransportRegistry {
 		
 		$message = array();
 		
-		if ( $this->getCurrentTransport()->isConfiguredAndReady() ) {
+		if ( $this->getSelectedTransport()->isConfiguredAndReady() ) {
 			if ( PostmanOptions::getInstance()->getRunMode() != PostmanOptions::RUN_MODE_PRODUCTION ) {
 				$message = array(
 					'error' => true,

--- a/Postman/Postman.php
+++ b/Postman/Postman.php
@@ -361,7 +361,7 @@ class Postman {
 				$this->messageHandler->addError( $message );
 			}
 		} else {
-			$transport = PostmanTransportRegistry::getInstance()->getCurrentTransport();
+			$transport = PostmanTransportRegistry::getInstance()->getSelectedTransport();
 			$scribe = $transport->getScribe();
 
 			$virgin = $options->isNew();

--- a/Postman/PostmanAdminController.php
+++ b/Postman/PostmanAdminController.php
@@ -247,7 +247,7 @@ if ( ! class_exists( 'PostmanAdminController' ) ) {
 		public function on_init() {
 			// only administrators should be able to trigger this
 			if ( PostmanUtils::isAdmin() ) {
-								$transport = PostmanTransportRegistry::getInstance()->getCurrentTransport();
+								$transport = PostmanTransportRegistry::getInstance()->getSelectedTransport();
 				$this->oauthScribe = $transport->getScribe();
 
 				// register content handlers


### PR DESCRIPTION
Replaces 3 deprecated methods with their non-deprecated equivalents across 5 files. All replacements are behavior-identical or thin wrappers:

- `getCurrentTransport()` → `getSelectedTransport()` (3 callers) — same logic, negated condition yields identical result
- `isSenderEmailOverridePrevented()` → `isPluginSenderEmailEnforced()` (2 callers) — thin wrapper
- `isSenderNameOverridePrevented()` → `isPluginSenderNameEnforced()` (2 callers) — thin wrapper

Fixes #103