### PR TITLE
fix(email-log): correct default values for get_all_logs and save methods

### DIFF
--- a/Postman/Postman-Email-Log/PostmanEmailQueryLog.php
+++ b/Postman/Postman-Email-Log/PostmanEmailQueryLog.php
@@ -299,7 +299,7 @@ class PostmanEmailQueryLog {
      * @since 2.5.0
      * @version 1.0.0
      */
-    public function get_all_logs( $ids = array() ) {
+    public function get_all_logs( $ids = array(-1) ) {
 
         $ids = implode( ',', $ids );
         $ids = $ids == -1 ? '' : "WHERE id IN ({$ids});";

--- a/Postman/PostmanEmailLogs.php
+++ b/Postman/PostmanEmailLogs.php
@@ -303,7 +303,7 @@ class PostmanEmailLogs {
      * @since 2.5.0
      * @version 1.0.0
      */
-    public function save( $data, $id = '' ) {
+    public function save( $data, $id = 0 ) {
         
         $data['time'] = !isset( $data['time'] ) ? current_time( 'timestamp' ) : $data['time'];
 


### PR DESCRIPTION
## Summary

Fixed two incorrect default parameter values caught by PHPStan. Both are small type-safe adjustments that prevent potential SQL issues and type mismatches.

Fixes #102

## Changes

### PostmanEmailQueryLog::get_all_logs()
**Before:**
```php
public function get_all_logs( $ids = array() ) {
```
**After:**
```php
public function get_all_logs( $ids = array(-1) ) {
```
**Why:** Empty array default produced `` after implode, so the `$ids == -1` guard never matched. SQL query would generate invalid `WHERE id IN ()` when no logs selected for export.

### PostmanEmailLogs::save()
**Before:**
```php
public function save( $data, $id = '' ) {
```
**After:**
```php
public function save( $data, $id = 0 ) {
```
**Why:** `$id` default was a string but `update()` expects an integer. The `!empty()` check works with both, but the type should match.

## Testing

**Test 1: Export CSV with no log items selected**
1. Go to Post SMTP > Email Log
2. Click Export without selecting any rows
3. Result: All logs are exported instead of invalid SQL error

**Test 2: Save log entry (new)**
1. Send a test email through Post SMTP
2. Check the Email Log
3. Result: Log entry saved successfully

**Test 3: Save log entry (update)**
1. Send an email (creates log entry)
2. Trigger an update to that log entry
3. Result: Log entry updated successfully