### PR TITLE
fix(notification): correct grammar in failure notification body

### DIFF
--- a/Postman/Extensions/Core/Notifications/PostmanNotify.php
+++ b/Postman/Extensions/Core/Notifications/PostmanNotify.php
@@ -293,7 +293,7 @@ class PostmanNotify {
 	 * @param string           $errorMessage
 	 */
 	public function notify( $log, $postmanMessage, $transcript, $transport, $errorMessage ) {
-		$message  = __( 'You getting this message because an error detected while delivered your email.', 'post-smtp' );
+		$message  = __( 'You are getting this message because an error was detected while delivering your email.', 'post-smtp' );
 		$message .= "\r\n" . sprintf( __( 'For the domain: %1$s', 'post-smtp' ), get_bloginfo( 'url' ) );
 		$message .= "\r\n" . __( 'The log to paste when you open a support issue:', 'post-smtp' ) . "\r\n";
 


### PR DESCRIPTION
## Summary

Fixed two grammar errors in the failure notification body string. The notification was sent to users during SMTP failures with broken English. Only the source string changed, no logic touched.

Fixes #76

## Changes

### Postman/Extensions/Core/Notifications/PostmanNotify.php

**Before:**
```
You getting this message because an error detected while delivered your email.
```

**After:**
```
You are getting this message because an error was detected while delivering your email.
```

**Why:** Missing verb 'are' and wrong participle tense. The string flows into all notification channels (email, pushover, slack, webhook) unchanged. `__()` wrap preserved, translators pick up the corrected source on next POT regen.

## Testing

Manual only (no automated test suite in repo):

1. Configure Post SMTP with invalid SMTP credentials
2. Send a test email - it fails
3. Check the notification channel (email/pushover/slack)
4. Confirm body reads the corrected sentence above

Result: Grammar fixed in notification output.