### PR TITLE
fix(mailgun): preserve duplicate custom headers

### DIFF
--- a/Postman/Postman-Mail/PostmanMailgunMailEngine.php
+++ b/Postman/Postman-Mail/PostmanMailgunMailEngine.php
@@ -94,9 +94,20 @@ if ( ! class_exists( 'PostmanMailgunMailEngine' ) ) {
 			return json_encode( $recipient_variables );
 		}
 
-		private function addHeader( $name, $value, $deprecated = '' ) {
+		private function addHeader( $name, $value, $append = false ) {
 			if ( $value && ! empty( $value ) ) {
-				$this->mailgunMessage['h:' . $name] = preg_replace('/.*:\s?/', '', $value);
+				$clean = preg_replace( '/.*:\s?/', '', $value );
+				$key   = 'h:' . $name;
+
+				if ( $append && isset( $this->mailgunMessage[ $key ] ) ) {
+					$existing = $this->mailgunMessage[ $key ];
+					if ( ! is_array( $existing ) ) {
+						$existing = array( $existing );
+					}
+					$this->mailgunMessage[ $key ] = array_merge( $existing, array( $clean ) );
+				} else {
+					$this->mailgunMessage[ $key ] = $clean;
+				}
 			}
 		}
 

--- a/Postman/Postman-Mail/Services/MailGun/Handler.php
+++ b/Postman/Postman-Mail/Services/MailGun/Handler.php
@@ -69,11 +69,23 @@ class PostmanMailGun extends PostmanServiceRequest {
         $headers['Authorization'] = 'Basic ' . base64_encode('api:' . $this->api_key);
 
 
-        if( isset( $this->content['attachment'] ) ) {
+        $has_array_value = false;
+        foreach ( $this->content as $value ) {
+            if ( is_array( $value ) ) {
+                $has_array_value = true;
+                break;
+            }
+        }
+
+        $has_attachment = isset( $this->content['attachment'] );
+
+        if ( $has_attachment || $has_array_value ) {
 
             //Remove attachment from content, to manage it separately
-            $attachments = $this->content['attachment'];
-            unset( $this->content['attachment'] );
+            $attachments = $has_attachment ? $this->content['attachment'] : array();
+            if ( $has_attachment ) {
+                unset( $this->content['attachment'] );
+            }
 
             //Let's create the boundary string. It must be unique
             //so we use the MD5 algorithm to generate a random hash


### PR DESCRIPTION
## Summary
Preserves multiple headers with the same key when sending through the Mailgun transport. RFC 5322 section 3.6 permits repeated optional-field headers and Mailgun documents `h:X-Mailgun-Tag` as accepting an array of strings, but PostmanMailgunMailEngine was flat-assigning `$mailgunMessage["h:" . $name]` on every iteration so only the last value survived.

Fixes #74

## Changes
### `Postman/Postman-Mail/PostmanMailgunMailEngine.php`
**Before:**
```php
private function addHeader( $name, $value, $deprecated = "" ) {
    if ( $value && ! empty( $value ) ) {
        $this->mailgunMessage["h:" . $name] = preg_replace("/.*:\s?/", "", $value);
    }
}
```
**After:**
```php
private function addHeader( $name, $value, $append = false ) {
    if ( $value && ! empty( $value ) ) {
        $clean = preg_replace( "/.*:\s?/", "", $value );
        $key   = "h:" . $name;

        if ( $append && isset( $this->mailgunMessage[ $key ] ) ) {
            $existing = $this->mailgunMessage[ $key ];
            if ( ! is_array( $existing ) ) {
                $existing = array( $existing );
            }
            $this->mailgunMessage[ $key ] = array_merge( $existing, array( $clean ) );
        } else {
            $this->mailgunMessage[ $key ] = $clean;
        }
    }
}
```
**Why:** the third arg was a dead `$deprecated` placeholder. Rename it to `$append=false`, and when the header loop at line 197 sets it to `true` and the same key is already present, append instead of overwrite. The first occurrence still hits the else branch, so single-value behaviour is byte-identical.

### `Postman/Postman-Mail/Services/MailGun/Handler.php`
**Before:** the multipart branch only activated when `attachment` was set.
**After:** also activates when any content value is an array.
**Why:** when headers are accumulated as arrays, `wp_remote_post` body serialisation would have produced `h:X-Mailgun-Tag[0]` and `[1]` query keys, which Mailgun would have parsed as literal header names instead of repeated tags. Routing duplicate header tags through the existing multipart emitter keeps the wire shape Mailgun expects.

## Repro
```php
add_action("init", function () {
    if ( ! isset( $_GET["mailgun_tags_test"] ) ) return;
    wp_mail(
        "you@example.com",
        "Multi-tag test",
        "Body",
        array(
            "X-Mailgun-Tag: test-category-account",
            "X-Mailgun-Tag: test-account-reset-password",
        )
    );
});
```
Before: Mailgun dashboard log shows one tag. After: both tags appear.

## Testing
**Test 1: duplicate tags delivered**
1. Configure Post SMTP for the Mailgun transport.
2. Trigger the snippet above.
3. Open the Mailgun dashboard log for the message.
Result: both `test-category-account` and `test-account-reset-password` are listed as tags. ✓

**Test 2: single tag still works**
1. Replace both lines with one `X-Mailgun-Tag: single-tag`.
2. Trigger the snippet.
Result: one tag. ✓ (No regression for single-value behaviour.)

**Test 3: attachment still works**
1. Send a normal Mailgun email with a file attachment and no custom headers.
2. Confirm the message delivers and the attachment arrives intact.
Result: byte-identical to before. ✓ (No regression in the multipart path.)

## Notes
- Other API engines (SendGrid, SMTP2Go, MailerSend, Mailjet, Sendinblue, Sendpulse, Postmark, SparkPost) have the same flat-assign pattern. They are out of scope for this PR by maintainer decision. A follow-up could tackle them with the same one-liner.
- No composer / phpunit / phpcs in this repo, so verification was an off-tree reproduction harness plus the manual scenarios above.