### PR TITLE
fix(controller): remove unreachable || true / && false guards

### DIFF
--- a/Postman/Postman-Controller/PostmanAdminPointer.php
+++ b/Postman/Postman-Controller/PostmanAdminPointer.php
@@ -24,7 +24,7 @@ if (! class_exists ( 'PostmanAdminPointer' )) {
 			$this->rootPluginFilenameAndPath = $rootPluginFilenameAndPath;
 
 			// Don't run on WP < 3.3
-			if (get_bloginfo ( 'version' ) < '3.3' || true)
+			if (version_compare ( get_bloginfo ( 'version' ), '3.3', '<' ))
 				return;
 
 			add_action ( 'admin_enqueue_scripts', array (
@@ -98,7 +98,7 @@ if (! class_exists ( 'PostmanAdminPointer' )) {
 		}
 		function wptuts_register_pointer_testing($p) {
 			// only do this for administrators
-			if (PostmanUtils::isAdmin () && false) {
+			if (PostmanUtils::isAdmin ()) {
 				$p ['postman16_log'] = array (
 						'target' => '.configure_manually',
 						'options' => array (


### PR DESCRIPTION
## Summary

Two debug-disable hacks in `Postman/Postman-Controller/PostmanAdminPointer.php` made the constructor's hook registrations and the pointer array build unreachable. Both are now removed. The WP version compare is also upgraded from a lexicographic string `<` to `version_compare()` so the guard stays correct on future WP releases.

Behaviour is unchanged at runtime because the class is loaded but never instantiated elsewhere.

Fixes #111

## Changes

### `Postman/Postman-Controller/PostmanAdminPointer.php`

**Constructor guard — Before:**

```php
// Don't run on WP < 3.3
if (get_bloginfo ( 'version' ) < '3.3' || true)
    return;
```

**Constructor guard — After:**

```php
// Don't run on WP < 3.3
if (version_compare ( get_bloginfo ( 'version' ), '3.3', '<' ))
    return;
```

**Why:** `|| true` forced an early return regardless of WP version, making the `add_action` and `add_filter` calls immediately below it unreachable. The lexicographic string compare was also broken: with `'10.x'` the expression `'10.0' < '3.3'` becomes true and the guard would fire on newer WP. `version_compare()` fixes both.

**Pointer registration guard — Before:**

```php
// only do this for administrators
if (PostmanUtils::isAdmin () && false) {
    $p ['postman16_log'] = array (
            'target' => '.configure_manually',
            ...
    );
    return $p;
}
```

**Pointer registration guard — After:**

```php
// only do this for administrators
if (PostmanUtils::isAdmin ()) {
    $p ['postman16_log'] = array (
            'target' => '.configure_manually',
            ...
    );
    return $p;
}
```

**Why:** `&& false` short-circuited the role check and skipped the pointer registration. `PostmanUtils::isAdmin()` is the actual intent.

## Testing

**Test 1: Syntax lint**
1. From a local clone: `php -l Postman/Postman-Controller/PostmanAdminPointer.php`
2. Result: reports `No syntax errors detected`. Confirmed in the fix branch.

**Test 2: Runtime smoke on a WP 5.6+ site**
1. Install and activate the plugin from the branch.
2. Load each admin page that Post SMTP owns: Post SMTP dashboard widget, Postman → Configuration, Email Log, Send Test Email, Connectivity Test.
3. Result: no PHP fatals, no notices, no warnings. Behaviour identical to `old/dev` because the class is still loaded but not instantiated.

**Test 3: Inline diff review**
1. Open `Postman/Postman-Controller/PostmanAdminPointer.php`.
2. Confirm L27 is now an honest version guard and L101 is now an honest role check.

## Notes

Two adjacent issues were observed during investigation and are intentionally not addressed in this PR so the diff stays surgical:

- `Postman/Postman-Email-Log/PostmanEmailLogService.php:285` has the same `|| true` debug-disable flavor. Worth a separate cleanup.
- The pointer JS asset `script/postman-admin-pointer.js` referenced at `PostmanAdminPointer.php:89` does not exist in the repo and the matching `wp_enqueue_script` block is commented out. So even if the class is later instantiated, the pointer will not render until the JS is added.

Happy to follow up on either in a separate issue if useful.
